### PR TITLE
Fix incorrect device FCntUp update

### DIFF
--- a/loraserver.go
+++ b/loraserver.go
@@ -127,8 +127,8 @@ func handleCollectedDataUpPackets(ctx Context, rxPackets RXPackets) error {
 		}
 	}
 
-	// increment counter
-	ns.FCntUp++
+	// sync counter with that of the device
+	ns.FCntUp = macPL.FHDR.FCnt
 	if err := saveNodeSession(ctx.RedisPool, ns); err != nil {
 		return fmt.Errorf("could not update node-session: %s", err)
 	}

--- a/loraserver_test.go
+++ b/loraserver_test.go
@@ -34,7 +34,7 @@ func TestHandleDataUpPackets(t *testing.T) {
 				DevEUI:   lorawan.EUI64{1, 2, 3, 4, 5, 6, 7, 8},
 				AppSKey:  lorawan.AES128Key{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
 				NwkSKey:  lorawan.AES128Key{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-				FCntUp:   10,
+				FCntUp:   8,
 				FCntDown: 0,
 
 				AppEUI: lorawan.EUI64{8, 7, 6, 5, 4, 3, 2, 1},
@@ -91,10 +91,10 @@ func TestHandleDataUpPackets(t *testing.T) {
 						So(data.Bytes, ShouldResemble, []byte("hello!"))
 					})
 
-					Convey("Then the FCntUp has been incremented", func() {
+					Convey("Then the FCntUp has been synchronized", func() {
 						nsUpdated, err := getNodeSession(p, ns.DevAddr)
 						So(err, ShouldBeNil)
-						So(nsUpdated.FCntUp, ShouldEqual, ns.FCntUp+1)
+						So(nsUpdated.FCntUp, ShouldEqual, macPL.FHDR.FCnt)
 					})
 				})
 

--- a/node_session.go
+++ b/node_session.go
@@ -40,7 +40,7 @@ type NodeSession struct {
 // Note that the LoRaWAN packet only contains the 16 LSB, so in order
 // to validate the MIC, the full 32 bit frame-counter needs to be set.
 // After a succesful validation of the FCntUP and the MIC, don't forget
-// to increment the Node FCntUp by 1.
+// to synchronize the Node FCntUp with the packet FCnt.
 func (n NodeSession) ValidateAndGetFullFCntUp(fCntUp uint32) (uint32, bool) {
 	// we need to compare the difference of the 16 LSB
 	gap := uint32(uint16(fCntUp) - uint16(n.FCntUp%65536))


### PR DESCRIPTION
Fix for issue #1.

For me it is not absolutely clear in the spec when the counter on the device should be updated, but it seems like this should be done before constructing the packet (i.e putting the counter in the FCnt field). This seems to be the case according to the example on page 73 around figure 15.

> The frame counter Cu is simply derived by adding 1 to the previous uplink frame counter.

The previous frame counter should be initially 0, so `Cu` (the FCnt on the packet) should already be incremented by one and no `+1` seem necessary on the server (I might be wrong about that, but I believe that I am not).