### PR TITLE
Update github.com/jacobsa/crypto/cmac vendor

### DIFF
--- a/vendor/github.com/jacobsa/crypto/cmac/hash_32bit.go
+++ b/vendor/github.com/jacobsa/crypto/cmac/hash_32bit.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build 386 arm,!arm64
+
 package cmac
 
 import (
@@ -28,16 +30,18 @@ func xorBlock(
 	// Check assumptions. (These are compile-time constants, so this should
 	// compile out.)
 	const wordSize = unsafe.Sizeof(uintptr(0))
-	if blockSize != 2*wordSize {
+	if blockSize != 4*wordSize {
 		log.Panicf("%d %d", blockSize, wordSize)
 	}
 
 	// Convert.
-	a := (*[2]uintptr)(aPtr)
-	b := (*[2]uintptr)(bPtr)
-	dst := (*[2]uintptr)(dstPtr)
+	a := (*[4]uintptr)(aPtr)
+	b := (*[4]uintptr)(bPtr)
+	dst := (*[4]uintptr)(dstPtr)
 
 	// Compute.
 	dst[0] = a[0] ^ b[0]
 	dst[1] = a[1] ^ b[1]
+	dst[2] = a[2] ^ b[2]
+	dst[3] = a[3] ^ b[3]
 }

--- a/vendor/github.com/jacobsa/crypto/cmac/hash_64bit.go
+++ b/vendor/github.com/jacobsa/crypto/cmac/hash_64bit.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build amd64 arm64
+
 package cmac
 
 import (
@@ -28,18 +30,16 @@ func xorBlock(
 	// Check assumptions. (These are compile-time constants, so this should
 	// compile out.)
 	const wordSize = unsafe.Sizeof(uintptr(0))
-	if blockSize != 4*wordSize {
+	if blockSize != 2*wordSize {
 		log.Panicf("%d %d", blockSize, wordSize)
 	}
 
 	// Convert.
-	a := (*[4]uintptr)(aPtr)
-	b := (*[4]uintptr)(bPtr)
-	dst := (*[4]uintptr)(dstPtr)
+	a := (*[2]uintptr)(aPtr)
+	b := (*[2]uintptr)(bPtr)
+	dst := (*[2]uintptr)(dstPtr)
 
 	// Compute.
 	dst[0] = a[0] ^ b[0]
 	dst[1] = a[1] ^ b[1]
-	dst[2] = a[2] ^ b[2]
-	dst[3] = a[3] ^ b[3]
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -40,8 +40,8 @@
 		},
 		{
 			"path": "github.com/jacobsa/crypto/cmac",
-			"revision": "bf13d379f5e7e0bbfc85ad339211f5c0dde70f95",
-			"revisionTime": "2016-02-18T11:02:31+11:00"
+			"revision": "42daa9d04c68a12aca47231abd9fb7f8aac27ef7",
+			"revisionTime": "2016-04-11T08:58:39+10:00"
 		},
 		{
 			"path": "github.com/jacobsa/crypto/common",


### PR DESCRIPTION
The new version of github.com/jacobsa/crypto/cmac compiles also for ARM
architecture (raspberry pi).