### PR TITLE
Fix node session app eui check on create

### DIFF
--- a/internal/loraserver/node_session.go
+++ b/internal/loraserver/node_session.go
@@ -239,16 +239,17 @@ func (a *NodeSessionAPI) Create(ns models.NodeSession, devAddr *lorawan.DevAddr)
 	}
 
 	// validate that the node exists
-	if _, err := getNode(a.ctx.DB, ns.DevEUI); err != nil {
+	var node models.Node
+	var err error
+	if node, err = getNode(a.ctx.DB, ns.DevEUI); err != nil {
 		return err
 	}
 
-	// validate that the app exists
-	if _, err := getApplication(a.ctx.DB, ns.AppEUI); err != nil {
-		return err
+	if ns.AppEUI != node.AppEUI {
+		return fmt.Errorf("Unexpected AppEUI while creating node session: %v", ns.AppEUI)
 	}
 
-	if err := createNodeSession(a.ctx.RedisPool, ns); err != nil {
+	if err = createNodeSession(a.ctx.RedisPool, ns); err != nil {
 		return err
 	}
 	*devAddr = ns.DevAddr


### PR DESCRIPTION
In the node session a node should have it's own AppEUI, not just an
existing one. Plus this change saves a DB request.