### PR TITLE
Add abstractions so that sql can be replaced

### DIFF
--- a/cmd/loraserver/main.go
+++ b/cmd/loraserver/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/elazarl/go-bindata-assetfs"
 	_ "github.com/lib/pq"
 
 	log "github.com/Sirupsen/logrus"
@@ -22,7 +23,6 @@ import (
 	"github.com/brocaar/lorawan"
 	"github.com/brocaar/lorawan/band"
 	"github.com/codegangsta/cli"
-	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/rubenv/sql-migrate"
 )
 
@@ -73,12 +73,22 @@ func run(c *cli.Context) {
 		log.WithField("count", n).Info("migrations applied")
 	}
 
+	nodeManager, err := loraserver.NewNodeManager(db)
+	if err != nil {
+		log.Fatalf("could not setup node manager: %v", err)
+	}
+	nodeApplicationsManager, err := loraserver.NewNodeApplicationsManager(db)
+	if err != nil {
+		log.Fatalf("could not setup node applications manager: %v", err)
+	}
+
 	ctx := loraserver.Context{
-		DB:          db,
-		RedisPool:   rp,
-		Gateway:     gw,
-		Application: app,
-		NetID:       netID,
+		NodeManager:    nodeManager,
+		NodeAppManager: nodeApplicationsManager,
+		RedisPool:      rp,
+		Gateway:        gw,
+		Application:    app,
+		NetID:          netID,
 	}
 
 	// start the loraserver

--- a/internal/loraserver/application.go
+++ b/internal/loraserver/application.go
@@ -1,79 +1,9 @@
 package loraserver
 
 import (
-	"errors"
-
 	"github.com/brocaar/loraserver/models"
 	"github.com/brocaar/lorawan"
-	"github.com/jmoiron/sqlx"
-
-	log "github.com/Sirupsen/logrus"
 )
-
-// createApplication creates the given Application
-func createApplication(db *sqlx.DB, a models.Application) error {
-	_, err := db.Exec("insert into application (app_eui, name) values ($1, $2)",
-		a.AppEUI[:],
-		a.Name,
-	)
-	if err == nil {
-		log.WithField("app_eui", a.AppEUI).Info("application created")
-	}
-	return err
-}
-
-// getApplication returns the Application for the given AppEUI.
-func getApplication(db *sqlx.DB, appEUI lorawan.EUI64) (models.Application, error) {
-	var app models.Application
-	return app, db.Get(&app, "select * from application where app_eui = $1", appEUI[:])
-}
-
-// getApplications returns a slice of applications.
-func getApplications(db *sqlx.DB, limit, offset int) ([]models.Application, error) {
-	var apps []models.Application
-	return apps, db.Select(&apps, "select * from application order by app_eui limit $1 offset $2", limit, offset)
-}
-
-// updateApplication updates the given Application.
-func updateApplication(db *sqlx.DB, a models.Application) error {
-	res, err := db.Exec("update application set name = $1 where app_eui = $2",
-		a.Name,
-		a.AppEUI[:],
-	)
-	if err != nil {
-		return err
-	}
-	ra, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if ra == 0 {
-		return errors.New("AppEUI did not match any rows")
-	}
-	log.WithField("app_eui", a.AppEUI).Info("application updated")
-	return nil
-}
-
-// deleteApplication deletes the Application matching the given AppEUI.
-// Note that this will delete all related nodes too!
-func deleteApplication(db *sqlx.DB, appEUI lorawan.EUI64) error {
-	res, err := db.Exec("delete from application where app_eui = $1",
-		appEUI[:],
-	)
-	if err != nil {
-		return err
-	}
-	ra, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if ra == 0 {
-		return errors.New("AppEUI did not match any rows")
-	}
-
-	log.WithField("app_eui", appEUI).Info("application deleted")
-	return nil
-}
 
 // ApplicationAPI exports the Application related functions.
 type ApplicationAPI struct {
@@ -90,20 +20,20 @@ func NewApplicationAPI(ctx Context) *ApplicationAPI {
 // Get returns the Application for the given AppEUI.
 func (a *ApplicationAPI) Get(appEUI lorawan.EUI64, app *models.Application) error {
 	var err error
-	*app, err = getApplication(a.ctx.DB, appEUI)
+	*app, err = a.ctx.NodeAppManager.get(appEUI)
 	return err
 }
 
 // GetList returns a list of applications (given a limit and offset).
 func (a *ApplicationAPI) GetList(req models.GetListRequest, apps *[]models.Application) error {
 	var err error
-	*apps, err = getApplications(a.ctx.DB, req.Limit, req.Offset)
+	*apps, err = a.ctx.NodeAppManager.getList(req.Limit, req.Offset)
 	return err
 }
 
 // Create creates the given application.
 func (a *ApplicationAPI) Create(app models.Application, appEUI *lorawan.EUI64) error {
-	if err := createApplication(a.ctx.DB, app); err != nil {
+	if err := a.ctx.NodeAppManager.create(app); err != nil {
 		return err
 	}
 	*appEUI = app.AppEUI
@@ -112,7 +42,7 @@ func (a *ApplicationAPI) Create(app models.Application, appEUI *lorawan.EUI64) e
 
 // Update updates the given Application.
 func (a *ApplicationAPI) Update(app models.Application, appEUI *lorawan.EUI64) error {
-	if err := updateApplication(a.ctx.DB, app); err != nil {
+	if err := a.ctx.NodeAppManager.update(app); err != nil {
 		return err
 	}
 	*appEUI = app.AppEUI
@@ -121,7 +51,7 @@ func (a *ApplicationAPI) Update(app models.Application, appEUI *lorawan.EUI64) e
 
 // Delete deletes the application for the given AppEUI.
 func (a *ApplicationAPI) Delete(appEUI lorawan.EUI64, deletedAppEUI *lorawan.EUI64) error {
-	if err := deleteApplication(a.ctx.DB, appEUI); err != nil {
+	if err := a.ctx.NodeAppManager.delete(appEUI); err != nil {
 		return err
 	}
 	*deletedAppEUI = appEUI

--- a/internal/loraserver/application_test.go
+++ b/internal/loraserver/application_test.go
@@ -15,9 +15,11 @@ func TestApplicationAPI(t *testing.T) {
 		db, err := OpenDatabase(conf.PostgresDSN)
 		So(err, ShouldBeNil)
 		mustResetDB(db)
+		nodeApplicationsManager, err := NewNodeApplicationsManager(db)
+		So(err, ShouldBeNil)
 
 		ctx := Context{
-			DB: db,
+			NodeAppManager: nodeApplicationsManager,
 		}
 
 		api := NewApplicationAPI(ctx)

--- a/internal/loraserver/context.go
+++ b/internal/loraserver/context.go
@@ -3,15 +3,15 @@ package loraserver
 import (
 	"github.com/brocaar/lorawan"
 	"github.com/garyburd/redigo/redis"
-	"github.com/jmoiron/sqlx"
 )
 
 // Context holds the context of a loraserver instance
 // (backends, db connections etc..)
 type Context struct {
-	DB          *sqlx.DB
-	RedisPool   *redis.Pool
-	Gateway     GatewayBackend
-	Application ApplicationBackend
-	NetID       lorawan.NetID
+	NodeManager    NodeManager
+	NodeAppManager NodeApplicationsManager
+	RedisPool      *redis.Pool
+	Gateway        GatewayBackend
+	Application    ApplicationBackend
+	NetID          lorawan.NetID
 }

--- a/internal/loraserver/interfaces.go
+++ b/internal/loraserver/interfaces.go
@@ -22,3 +22,21 @@ type ApplicationBackend interface {
 	TXPayloadChan() chan models.TXPayload                                                        // channel containing the received payloads from the application
 	Close() error                                                                                // close the application backend
 }
+
+// NodeManager is the interface for managing the known nodes to the system.
+type NodeManager interface {
+	create(n models.Node) error                       // create creates a given Node
+	update(n models.Node) error                       // update updates the given Node.
+	delete(devEUI lorawan.EUI64) error                // delete deletes the Node matching the given DevEUI.
+	get(devEUI lorawan.EUI64) (models.Node, error)    // get returns the Node for the given DevEUI.
+	getList(limit, offset int) ([]models.Node, error) // getList returns a slice of nodes, sorted by DevEUI.
+}
+
+// NodeApplicationsManager is the interface for managing the applications to which nodes can belong.
+type NodeApplicationsManager interface {
+	create(n models.Application) error                       // create creates a given Application.
+	update(n models.Application) error                       // update updates the given Application.
+	delete(appEUI lorawan.EUI64) error                       // delete deletes the Application matching the given EUI.
+	get(appEUI lorawan.EUI64) (models.Application, error)    // get returns the Application for the given EUI.
+	getList(limit, offset int) ([]models.Application, error) // getList returns a slice of applications.
+}

--- a/internal/loraserver/loraserver.go
+++ b/internal/loraserver/loraserver.go
@@ -352,7 +352,7 @@ func validateAndCollectJoinRequestPacket(ctx Context, rxPacket models.RXPacket) 
 	}
 
 	// get node information for this DevEUI
-	node, err := getNode(ctx.DB, jrPL.DevEUI)
+	node, err := ctx.NodeManager.get(jrPL.DevEUI)
 	if err != nil {
 		return fmt.Errorf("could not get node: %s", err)
 	}
@@ -396,7 +396,7 @@ func handleCollectedJoinRequestPackets(ctx Context, rxPackets RXPackets) error {
 	}
 
 	// get node information for this DevEUI
-	node, err := getNode(ctx.DB, jrPL.DevEUI)
+	node, err := ctx.NodeManager.get(jrPL.DevEUI)
 	if err != nil {
 		return fmt.Errorf("could not get node: %s", err)
 	}
@@ -443,7 +443,7 @@ func handleCollectedJoinRequestPackets(ctx Context, rxPackets RXPackets) error {
 	}
 
 	// update the node (with updated used dev-nonces)
-	if err = updateNode(ctx.DB, node); err != nil {
+	if err = ctx.NodeManager.update(node); err != nil {
 		return fmt.Errorf("could not update the node: %s", err)
 	}
 

--- a/internal/loraserver/node_session.go
+++ b/internal/loraserver/node_session.go
@@ -241,7 +241,7 @@ func (a *NodeSessionAPI) Create(ns models.NodeSession, devAddr *lorawan.DevAddr)
 	// validate that the node exists
 	var node models.Node
 	var err error
-	if node, err = getNode(a.ctx.DB, ns.DevEUI); err != nil {
+	if node, err = a.ctx.NodeManager.get(ns.DevEUI); err != nil {
 		return err
 	}
 

--- a/internal/loraserver/node_session_test.go
+++ b/internal/loraserver/node_session_test.go
@@ -115,11 +115,16 @@ func TestNodeSessionAPI(t *testing.T) {
 		mustResetDB(db)
 		p := NewRedisPool(conf.RedisURL)
 		mustFlushRedis(p)
+		nodeManager, err := NewNodeManager(db)
+		So(err, ShouldBeNil)
+		nodeApplicationsManager, err := NewNodeApplicationsManager(db)
+		So(err, ShouldBeNil)
 
 		ctx := Context{
-			DB:        db,
-			RedisPool: p,
-			NetID:     [3]byte{1, 2, 3},
+			NodeManager:    nodeManager,
+			NodeAppManager: nodeApplicationsManager,
+			RedisPool:      p,
+			NetID:          [3]byte{1, 2, 3},
 		}
 
 		api := NewNodeSessionAPI(ctx)
@@ -129,7 +134,7 @@ func TestNodeSessionAPI(t *testing.T) {
 				AppEUI: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
 				Name:   "test app",
 			}
-			So(createApplication(ctx.DB, app), ShouldBeNil)
+			So(ctx.NodeAppManager.create(app), ShouldBeNil)
 
 			node := models.Node{
 				DevEUI:        [8]byte{8, 7, 6, 5, 4, 3, 2, 1},
@@ -137,7 +142,7 @@ func TestNodeSessionAPI(t *testing.T) {
 				AppKey:        [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 				UsedDevNonces: [][2]byte{},
 			}
-			So(createNode(ctx.DB, node), ShouldBeNil)
+			So(ctx.NodeManager.create(node), ShouldBeNil)
 
 			ns := models.NodeSession{
 				DevAddr:  [4]byte{6, 2, 3, 4},

--- a/internal/loraserver/node_test.go
+++ b/internal/loraserver/node_test.go
@@ -148,9 +148,14 @@ func TestNodeAPI(t *testing.T) {
 		db, err := OpenDatabase(conf.PostgresDSN)
 		So(err, ShouldBeNil)
 		mustResetDB(db)
+		nodeManager, err := NewNodeManager(db)
+		So(err, ShouldBeNil)
+		nodeApplicationsManager, err := NewNodeApplicationsManager(db)
+		So(err, ShouldBeNil)
 
 		ctx := Context{
-			DB: db,
+			NodeManager:    nodeManager,
+			NodeAppManager: nodeApplicationsManager,
 		}
 
 		api := NewNodeAPI(ctx)
@@ -161,7 +166,7 @@ func TestNodeAPI(t *testing.T) {
 				Name:   "test app",
 			}
 			// we need to create the app since the node has a fk constraint
-			So(createApplication(ctx.DB, app), ShouldBeNil)
+			So(ctx.NodeAppManager.create(app), ShouldBeNil)
 
 			node := models.Node{
 				DevEUI:        [8]byte{8, 7, 6, 5, 4, 3, 2, 1},

--- a/internal/loraserver/sql_node_app_manager.go
+++ b/internal/loraserver/sql_node_app_manager.go
@@ -1,0 +1,85 @@
+package loraserver
+
+import (
+	"errors"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/brocaar/loraserver/models"
+	"github.com/brocaar/lorawan"
+	"github.com/jmoiron/sqlx"
+)
+
+// SQLNodeApplicationsManager implements a SQL version of the NodeApplicationsManager.
+type SQLNodeApplicationsManager struct {
+	DB *sqlx.DB
+}
+
+// NewNodeApplicationsManager creates a new SQLNodeApplicationsManager.
+func NewNodeApplicationsManager(db *sqlx.DB) (NodeApplicationsManager, error) {
+	return &SQLNodeApplicationsManager{db}, nil
+}
+
+// create creates the given Application
+func (s *SQLNodeApplicationsManager) create(a models.Application) error {
+	_, err := s.DB.Exec("insert into application (app_eui, name) values ($1, $2)",
+		a.AppEUI[:],
+		a.Name,
+	)
+	if err == nil {
+		log.WithField("app_eui", a.AppEUI).Info("application created")
+	}
+	return err
+}
+
+// get returns the Application for the given AppEUI.
+func (s *SQLNodeApplicationsManager) get(appEUI lorawan.EUI64) (models.Application, error) {
+	var app models.Application
+	return app, s.DB.Get(&app, "select * from application where app_eui = $1", appEUI[:])
+}
+
+// getList returns a slice of applications.
+func (s *SQLNodeApplicationsManager) getList(limit, offset int) ([]models.Application, error) {
+	var apps []models.Application
+	return apps, s.DB.Select(&apps, "select * from application order by app_eui limit $1 offset $2", limit, offset)
+}
+
+// update updates the given Application.
+func (s *SQLNodeApplicationsManager) update(a models.Application) error {
+	res, err := s.DB.Exec("update application set name = $1 where app_eui = $2",
+		a.Name,
+		a.AppEUI[:],
+	)
+	if err != nil {
+		return err
+	}
+	ra, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if ra == 0 {
+		return errors.New("AppEUI did not match any rows")
+	}
+	log.WithField("app_eui", a.AppEUI).Info("application updated")
+	return nil
+}
+
+// delete deletes the Application matching the given AppEUI.
+// Note that this will delete all related nodes too!
+func (s *SQLNodeApplicationsManager) delete(appEUI lorawan.EUI64) error {
+	res, err := s.DB.Exec("delete from application where app_eui = $1",
+		appEUI[:],
+	)
+	if err != nil {
+		return err
+	}
+	ra, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if ra == 0 {
+		return errors.New("AppEUI did not match any rows")
+	}
+
+	log.WithField("app_eui", appEUI).Info("application deleted")
+	return nil
+}

--- a/internal/loraserver/sql_node_manager.go
+++ b/internal/loraserver/sql_node_manager.go
@@ -1,0 +1,86 @@
+package loraserver
+
+import (
+	"errors"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/brocaar/loraserver/models"
+	"github.com/brocaar/lorawan"
+	"github.com/jmoiron/sqlx"
+)
+
+// SQLNodeManager implements a SQL version of the NodeManager.
+type SQLNodeManager struct {
+	DB *sqlx.DB
+}
+
+// NewNodeManager creates a new SQLNodeManager.
+func NewNodeManager(db *sqlx.DB) (NodeManager, error) {
+	return &SQLNodeManager{db}, nil
+}
+
+// create creates the given Node.
+func (s *SQLNodeManager) create(n models.Node) error {
+	_, err := s.DB.Exec("insert into node (dev_eui, app_eui, app_key) values ($1, $2, $3)",
+		n.DevEUI[:],
+		n.AppEUI[:],
+		n.AppKey[:],
+	)
+	if err == nil {
+		log.WithField("dev_eui", n.DevEUI).Info("node created")
+	}
+	return err
+}
+
+// update updates the given Node.
+func (s *SQLNodeManager) update(n models.Node) error {
+	res, err := s.DB.Exec("update node set app_eui = $1, app_key = $2, used_dev_nonces = $3 where dev_eui = $4",
+		n.AppEUI[:],
+		n.AppKey[:],
+		n.UsedDevNonces,
+		n.DevEUI[:],
+	)
+	if err != nil {
+		return err
+	}
+	ra, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if ra == 0 {
+		return errors.New("DevEUI did not match any rows")
+	}
+	log.WithField("dev_eui", n.DevEUI).Info("node updated")
+	return nil
+}
+
+// delete deletes the Node matching the given DevEUI.
+func (s *SQLNodeManager) delete(devEUI lorawan.EUI64) error {
+	res, err := s.DB.Exec("delete from node where dev_eui = $1",
+		devEUI[:],
+	)
+	if err != nil {
+		return err
+	}
+	ra, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if ra == 0 {
+		return errors.New("DevEUI did not match any rows")
+	}
+	log.WithField("dev_eui", devEUI).Info("node deleted")
+	return nil
+}
+
+// get returns the Node for the given DevEUI.
+func (s *SQLNodeManager) get(devEUI lorawan.EUI64) (models.Node, error) {
+	var node models.Node
+	return node, s.DB.Get(&node, "select * from node where dev_eui = $1", devEUI[:])
+}
+
+// getList returns a slice of nodes, sorted by DevEUI.
+func (s *SQLNodeManager) getList(limit, offset int) ([]models.Node, error) {
+	var nodes []models.Node
+	return nodes, s.DB.Select(&nodes, "select * from node order by dev_eui limit $1 offset $2", limit, offset)
+}


### PR DESCRIPTION
Two interfaces are added for managing the nodes and managing the node
applications. The code that directly uses the sql is reformatted to fit
in the interfaces. The code that depends on the reformatted code now
uses the interfaces.

This change is a part of an idea for making the use of nosql databases simple (two interface implementations away).

**Note**: Most of the changes are code being moved from one place to another or calling the given code through the new interfaces.