### PR TITLE
Fix path env var in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.6.2
 
 ENV PROJECT_PATH=/go/src/github.com/brocaar/loraserver
-ENV PATH=$PATH:$PROJECT_PATH/bin
+ENV PATH=$PATH:$PROJECT_PATH/build
 
 # install tools
 RUN go get github.com/golang/lint/golint


### PR DESCRIPTION
After the change of build location from `bin` to `build` the Dockerfile was
not changed. Fixing this so that the docker image can be used on it's own 
without changing the CMD command.