### PR TITLE
Increase Timestamp size

### DIFF
--- a/internal/loraserver/join_request_accept.go
+++ b/internal/loraserver/join_request_accept.go
@@ -169,7 +169,7 @@ func handleCollectedJoinRequestPackets(ctx Context, rxPackets RXPackets) error {
 	txPacket := models.TXPacket{
 		TXInfo: models.TXInfo{
 			MAC:       rxPacket.RXInfo.MAC,
-			Timestamp: rxPacket.RXInfo.Timestamp + uint32(Band.JoinAcceptDelay1/time.Microsecond),
+			Timestamp: rxPacket.RXInfo.Timestamp + uint64(Band.JoinAcceptDelay1/time.Microsecond),
 			Frequency: Band.DownlinkChannels[rx1Channel].Frequency,
 			Power:     Band.DefaultTXPower,
 			DataRate:  Band.DataRates[rx1DR],

--- a/internal/loraserver/loraserver.go
+++ b/internal/loraserver/loraserver.go
@@ -367,7 +367,7 @@ func handleDataDownReply(ctx Context, rxPacket models.RXPacket, ns models.NodeSe
 	txPacket := models.TXPacket{
 		TXInfo: models.TXInfo{
 			MAC:       rxPacket.RXInfo.MAC,
-			Timestamp: rxPacket.RXInfo.Timestamp + uint32(rxDelay/time.Microsecond),
+			Timestamp: rxPacket.RXInfo.Timestamp + uint64(rxDelay/time.Microsecond),
 			Frequency: Band.DownlinkChannels[rx1Channel].Frequency,
 			Power:     Band.DefaultTXPower,
 			DataRate:  Band.DataRates[rx1DR],

--- a/models/packets.go
+++ b/models/packets.go
@@ -17,7 +17,7 @@ type RXPacket struct {
 type RXInfo struct {
 	MAC       lorawan.EUI64 `json:"mac"`       // MAC address of the gateway
 	Time      time.Time     `json:"time"`      // receive time
-	Timestamp uint32        `json:"timestamp"` // gateway internal receive timestamp with microsecond precision, will rollover every ~ 72 minutes
+	Timestamp uint64        `json:"timestamp"` // gateway internal receive timestamp with microsecond precision, will rollover every ~ 72 minutes
 	Frequency int           `json:"frequency"` // frequency in Hz
 	Channel   int           `json:"channel"`   // concentrator IF channel used for RX
 	RFChain   int           `json:"rfChain"`   // RF chain used for RX
@@ -40,7 +40,7 @@ type TXPacket struct {
 type TXInfo struct {
 	MAC         lorawan.EUI64 `json:"mac"`         // MAC address of the gateway
 	Immediately bool          `json:"immediately"` // send the packet immediately (ignore Time)
-	Timestamp   uint32        `json:"timestamp"`   // gateway internal receive timestamp with microsecond precision, will rollover every ~ 72 minutes
+	Timestamp   uint64        `json:"timestamp"`   // gateway internal receive timestamp with microsecond precision, will rollover every ~ 72 minutes
 	Frequency   int           `json:"frequency"`   // frequency in Hz
 	Power       int           `json:"power"`       // TX power to use in dBm
 	DataRate    band.DataRate `json:"dataRate"`    // TX datarate (either LoRa or FSK)


### PR DESCRIPTION
Changing Timestamp from uint32 to uint64. uint32 is causing compatibility issue with NEMEUS packet-forwarder gateway.