### PR TITLE
Support custom TTN packet forwarder stat fields

### DIFF
--- a/models/packets.go
+++ b/models/packets.go
@@ -56,6 +56,9 @@ type GatewayStatsPacket struct {
 	Altitude            float64       `json:"altitude"`
 	RXPacketsReceived   int           `json:"rxPacketsReceived"`
 	RXPacketsReceivedOK int           `json:"rxPacketsReceivedOK"`
+	Platform            string        `json:"platform"`
+	ContactEmail        string        `json:"contactEmail"`
+	Description         string        `json:"description"`
 }
 
 // RXPayload contains the received (decrypted) payload from the node


### PR DESCRIPTION
This PR adds three fields to the `GatewayStatsPacket` struct to support some custom fields in the packet forwarder that is often used by The Things Network gateways.

Refs brocaar/lora-gateway-bridge#8

See also https://github.com/TheThingsNetwork/packet_forwarder/commit/faa525b1c517f481727b8b313e19a84c5bc573e7