### PR TITLE
Add TxPacketsEmitted (txnb in Semtech protocol)

### DIFF
--- a/models/packets.go
+++ b/models/packets.go
@@ -56,6 +56,7 @@ type GatewayStatsPacket struct {
 	Altitude            float64       `json:"altitude"`
 	RXPacketsReceived   int           `json:"rxPacketsReceived"`
 	RXPacketsReceivedOK int           `json:"rxPacketsReceivedOK"`
+	TxPacketsEmitted    int           `json:"txPacketsEmitted"`
 }
 
 // RXPayload contains the received (decrypted) payload from the node


### PR DESCRIPTION
This PR adds the `TxPacketsEmitted` field to the `GatewayStatsPacket` struct in order to store the `txnb` field from the Semtech Gateway Protocol.