### PR TITLE
Patched the minor bug for *Missing AppEUI check*

### DIFF
--- a/internal/loraserver/join_request_accept.go
+++ b/internal/loraserver/join_request_accept.go
@@ -21,7 +21,7 @@ func validateAndCollectJoinRequestPacket(ctx Context, rxPacket models.RXPacket) 
 	}
 
 	// get node information for this DevEUI
-	node, err := getNode(ctx.DB, jrPL.DevEUI)
+	node, err := getNode(ctx.DB, jrPL.DevEUI, jrPL.AppEUI)
 	if err != nil {
 		return err
 	}
@@ -66,8 +66,8 @@ func handleCollectedJoinRequestPackets(ctx Context, rxPackets RXPackets) error {
 		"mtype":    rxPackets[0].PHYPayload.MHDR.MType,
 	}).Info("packet(s) collected")
 
-	// get node information for this DevEUI
-	node, err := getNode(ctx.DB, jrPL.DevEUI)
+	// get node information for this DevEUI and it's AppEUI
+	node, err := getNode(ctx.DB, jrPL.DevEUI, jrPL.AppEUI)
 	if err != nil {
 		return err
 	}

--- a/internal/loraserver/node.go
+++ b/internal/loraserver/node.go
@@ -113,9 +113,9 @@ func deleteNode(db *sqlx.DB, devEUI lorawan.EUI64) error {
 }
 
 // getNode returns the Node for the given DevEUI.
-func getNode(db *sqlx.DB, devEUI lorawan.EUI64) (models.Node, error) {
+func getNode(db *sqlx.DB, devEUI lorawan.EUI64, appEUI lorawan.EUI64) (models.Node, error) {
 	var node models.Node
-	err := db.Get(&node, "select * from node where dev_eui = $1", devEUI[:])
+	err := db.Get(&node, "select * from node where dev_eui = $1 and app_eui = $2", devEUI[:], appEUI[:])
 	if err != nil {
 		return node, fmt.Errorf("get node %s error: %s", devEUI, err)
 	}
@@ -307,9 +307,9 @@ func NewNodeAPI(ctx Context) *NodeAPI {
 }
 
 // Get returns the Node for the given DevEUI.
-func (a *NodeAPI) Get(devEUI lorawan.EUI64, node *models.Node) error {
+func (a *NodeAPI) Get(devEUI lorawan.EUI64, appEUI lorawan.EUI64, node *models.Node) error {
 	var err error
-	*node, err = getNode(a.ctx.DB, devEUI)
+	*node, err = getNode(a.ctx.DB, devEUI, appEUI)
 	return err
 }
 

--- a/internal/loraserver/node_session.go
+++ b/internal/loraserver/node_session.go
@@ -380,7 +380,7 @@ func (a *NodeSessionAPI) Create(ns models.NodeSession, devAddr *lorawan.DevAddr)
 	// validate that the node exists
 	var node models.Node
 	var err error
-	if node, err = getNode(a.ctx.DB, ns.DevEUI); err != nil {
+	if node, err = getNode(a.ctx.DB, ns.DevEUI, ns.AppEUI); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Patched the minor bug for, [Missing AppEUI check](https://github.com/brocaar/loraserver/issues/34)

* Now while attempting `getNode()`, the mentioned functions passes the
`appEUI` of the device along with it's `devEUI` to the select query.

* All the use cases of the `getNode()` got updated accordingly matching
it's definition.