### PR TITLE
add time to the rxpayload

### DIFF
--- a/docs/receiving-data.md
+++ b/docs/receiving-data.md
@@ -21,7 +21,8 @@ Topic for payloads received from your nodes. Example payload:
     "devEUI": "0202020202020202",  // device EUI
     "fPort": 5,                    // FPort
     "gatewayCount": 3,             // number of gateways receiving this payload
-	"rssi": -59,                   // signal strength
+    "rssi": -59,                   // signal strength
+    "time": "2016-05-01T10:50:54.973189Z", // when the message has been received
     "data": "..."                  // base64 encoded payload (decrypted)
 }
 ```

--- a/internal/backend/application/backend_test.go
+++ b/internal/backend/application/backend_test.go
@@ -48,6 +48,7 @@ func TestBackend(t *testing.T) {
 
 					rxPacket := models.RXPayload{
 						DevEUI: devEUI,
+						Time:   time.Now().UTC(),
 					}
 					So(backend.SendRXPayload(appEUI, devEUI, rxPacket), ShouldBeNil)
 

--- a/internal/loraserver/uplink_data.go
+++ b/internal/loraserver/uplink_data.go
@@ -144,6 +144,7 @@ func handleCollectedDataUpPackets(ctx Context, rxPackets RXPackets) error {
 
 			err = ctx.Application.SendRXPayload(ns.AppEUI, ns.DevEUI, models.RXPayload{
 				DevEUI:       ns.DevEUI,
+				Time:         rxPacket.RXInfo.Time,
 				GatewayCount: len(rxPackets),
 				FPort:        *macPL.FPort,
 				RSSI:         rxPacket.RXInfo.RSSI,

--- a/models/packets.go
+++ b/models/packets.go
@@ -64,6 +64,7 @@ type GatewayStatsPacket struct {
 // which will be sent to the application.
 type RXPayload struct {
 	DevEUI       lorawan.EUI64 `json:"devEUI"`
+	Time         time.Time     `json:"time"`
 	FPort        uint8         `json:"fPort"`
 	GatewayCount int           `json:"gatewayCount"`
 	RSSI         int           `json:"rssi"`


### PR DESCRIPTION
I get an error in the test:
```
Failures:

  * /go/src/github.com/brocaar/loraserver/internal/backend/application/backend_test.go 
  Line 56:
  Expected: 'models.RXPayload{DevEUI:[8]uint8{1, 1, 1, 1, 1, 1, 1, 1}, Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}, FPort:0, GatewayCount:0, RSSI:0, Data:[]uint8(nil)}'
  Actual:   'models.RXPayload{DevEUI:[8]uint8{1, 1, 1, 1, 1, 1, 1, 1}, Time:time.Time{sec:0, nsec:0, loc:(*time.Location){name:"UTC", zone:[]time.zone(nil), tx:[]time.zoneTrans(nil), cacheStart:0, cacheEnd:0, cacheZone:(*time.zone)(nil)}}, FPort:0, GatewayCount:0, RSSI:0, Data:[]uint8(nil)}'
  (Should resemble)!
```
Honestly I don't know how to fix it.

#51 