### PR TITLE
Support multiple node-sessions using one DevAddr

### DIFF
--- a/cmd/loraserver/main.go
+++ b/cmd/loraserver/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/brocaar/loraserver/internal/backend/controller"
 	"github.com/brocaar/loraserver/internal/backend/gateway"
 	"github.com/brocaar/loraserver/internal/common"
+	"github.com/brocaar/loraserver/internal/migration"
 	"github.com/brocaar/loraserver/internal/uplink"
 	"github.com/brocaar/lorawan"
 	"github.com/brocaar/lorawan/band"
@@ -82,6 +83,11 @@ func run(c *cli.Context) error {
 	}).Info("starting LoRa Server")
 
 	lsCtx := mustGetContext(netID, c)
+
+	// migrate old node-session keys to new layout
+	if err = migration.MigrateNodeSessionDevAddrDevEUI(lsCtx.RedisPool); err != nil {
+		log.Fatalf("node-session migration error: %s", err)
+	}
 
 	// start the api server
 	log.WithFields(log.Fields{

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.15.0
+
+**Features:**
+
+* Node-sessions are now stored by `DevEUI`. Before the node-sessions were stored
+  by `DevAddr`. In case a single `DevAddr` is used by multiple nodes, the
+  `NwkSKey` is used for retrieving the corresponding node-session.
+
+*Note:* Data will be automatically migrated into the new format. As this process
+is not reversible it is recommended to make a backup of the Redis database before
+upgrading.
+
 ## 0.14.1
 
 **Bugfixes:**

--- a/internal/adr/adr_test.go
+++ b/internal/adr/adr_test.go
@@ -317,7 +317,7 @@ func TestADR(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(tst.NodeSession, ShouldResemble, &tst.ExpectedNodeSession)
 
-						macPayloadQueue, err := maccommand.ReadQueue(p, tst.NodeSession.DevAddr)
+						macPayloadQueue, err := maccommand.ReadQueue(p, tst.NodeSession.DevEUI)
 						So(err, ShouldBeNil)
 						So(macPayloadQueue, ShouldResemble, tst.ExpectedMACPayloadQueue)
 

--- a/internal/adr/adr_test.go
+++ b/internal/adr/adr_test.go
@@ -306,7 +306,7 @@ func TestADR(t *testing.T) {
 
 				for i, tst := range testTable {
 					Convey(fmt.Sprintf("Test: %s [%d]", tst.Name, i), func() {
-						So(session.CreateNodeSession(p, *tst.NodeSession), ShouldBeNil)
+						So(session.SaveNodeSession(p, *tst.NodeSession), ShouldBeNil)
 
 						err := HandleADR(ctx, tst.NodeSession, tst.RXPacket, tst.FullFCnt)
 						if tst.ExpectedError != nil {

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -83,7 +83,7 @@ func (n *NetworkServerAPI) GetNodeSession(ctx context.Context, req *ns.GetNodeSe
 	var devEUI lorawan.EUI64
 	copy(devEUI[:], req.DevEUI)
 
-	sess, err := session.GetNodeSessionByDevEUI(n.ctx.RedisPool, devEUI)
+	sess, err := session.GetNodeSession(n.ctx.RedisPool, devEUI)
 	if err != nil {
 		return nil, grpc.Errorf(codes.Unknown, err.Error())
 	}
@@ -122,7 +122,7 @@ func (n *NetworkServerAPI) UpdateNodeSession(ctx context.Context, req *ns.Update
 	copy(devEUI[:], req.DevEUI)
 	copy(appEUI[:], req.AppEUI)
 
-	sess, err := session.GetNodeSession(n.ctx.RedisPool, devAddr)
+	sess, err := session.GetNodeSession(n.ctx.RedisPool, devEUI)
 	if err != nil {
 		return nil, grpc.Errorf(codes.Unknown, err.Error())
 	}
@@ -181,7 +181,7 @@ func (n *NetworkServerAPI) DeleteNodeSession(ctx context.Context, req *ns.Delete
 	var devEUI lorawan.EUI64
 	copy(devEUI[:], req.DevEUI)
 
-	sess, err := session.GetNodeSessionByDevEUI(n.ctx.RedisPool, devEUI)
+	sess, err := session.GetNodeSession(n.ctx.RedisPool, devEUI)
 	if err != nil {
 		return nil, grpc.Errorf(codes.Unknown, err.Error())
 	}
@@ -223,7 +223,7 @@ func (n *NetworkServerAPI) PushDataDown(ctx context.Context, req *ns.PushDataDow
 	var devEUI lorawan.EUI64
 	copy(devEUI[:], req.DevEUI)
 
-	sess, err := session.GetNodeSessionByDevEUI(n.ctx.RedisPool, devEUI)
+	sess, err := session.GetNodeSession(n.ctx.RedisPool, devEUI)
 	if err != nil {
 		return nil, errToRPCError(err)
 	}

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -71,6 +71,10 @@ func (n *NetworkServerAPI) CreateNodeSession(ctx context.Context, req *ns.Create
 		return nil, grpc.Errorf(codes.Unknown, err.Error())
 	}
 
+	if err := maccommand.FlushQueue(n.ctx.RedisPool, sess.DevEUI); err != nil {
+		return nil, grpc.Errorf(codes.Unknown, err.Error())
+	}
+
 	return &ns.CreateNodeSessionResponse{}, nil
 }
 

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -59,7 +59,15 @@ func (n *NetworkServerAPI) CreateNodeSession(ctx context.Context, req *ns.Create
 	copy(sess.DevEUI[:], req.DevEUI)
 	copy(sess.NwkSKey[:], req.NwkSKey)
 
-	if err := session.CreateNodeSession(n.ctx.RedisPool, sess); err != nil {
+	exists, err := session.NodeSessionExists(n.ctx.RedisPool, sess.DevEUI)
+	if err != nil {
+		return nil, grpc.Errorf(codes.Internal, err.Error())
+	}
+	if exists {
+		return nil, grpc.Errorf(codes.AlreadyExists, err.Error())
+	}
+
+	if err := session.SaveNodeSession(n.ctx.RedisPool, sess); err != nil {
 		return nil, grpc.Errorf(codes.Unknown, err.Error())
 	}
 

--- a/internal/downlink/data.go
+++ b/internal/downlink/data.go
@@ -186,7 +186,7 @@ func HandlePushDataDown(ctx common.Context, ns session.NodeSession, confirmed bo
 
 	// remove the transmitted mac commands from the queue
 	for _, qi := range macQueueItems {
-		if err = maccommand.DeleteQueueItem(ctx.RedisPool, ns.DevAddr, qi); err != nil {
+		if err = maccommand.DeleteQueueItem(ctx.RedisPool, ns.DevEUI, qi); err != nil {
 			return errors.Wrap(err, "delete mac-command queue item error")
 		}
 	}
@@ -262,7 +262,7 @@ func SendUplinkResponse(ctx common.Context, ns session.NodeSession, rxPacket mod
 
 	// remove the transmitted mac commands from the queue
 	for _, qi := range macQueueItems {
-		if err = maccommand.DeleteQueueItem(ctx.RedisPool, ns.DevAddr, qi); err != nil {
+		if err = maccommand.DeleteQueueItem(ctx.RedisPool, ns.DevEUI, qi); err != nil {
 			return fmt.Errorf("delete mac-command queue item from queue error: %s", err)
 		}
 	}
@@ -380,7 +380,7 @@ func getAndFilterMACQueueItems(ctx common.Context, ns session.NodeSession, allow
 	var encrypted bool
 
 	// read the mac payload queue
-	queueItems, err := maccommand.ReadQueue(ctx.RedisPool, ns.DevAddr)
+	queueItems, err := maccommand.ReadQueue(ctx.RedisPool, ns.DevEUI)
 	if err != nil {
 		return nil, false, false, fmt.Errorf("read mac-payload tx queue error: %s", err)
 	}

--- a/internal/maccommand/maccommand_test.go
+++ b/internal/maccommand/maccommand_test.go
@@ -26,7 +26,7 @@ func TestHandle(t *testing.T) {
 			ns := session.NodeSession{
 				DevEUI: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
 			}
-			So(session.CreateNodeSession(p, ns), ShouldBeNil)
+			So(session.SaveNodeSession(p, ns), ShouldBeNil)
 
 			Convey("Testing LinkADRAns", func() {
 				linkADRReq := &lorawan.LinkADRReqPayload{

--- a/internal/maccommand/queue.go
+++ b/internal/maccommand/queue.go
@@ -11,7 +11,6 @@ import (
 	"github.com/garyburd/redigo/redis"
 
 	"github.com/brocaar/loraserver/internal/common"
-	"github.com/brocaar/loraserver/internal/session"
 	"github.com/brocaar/lorawan"
 )
 
@@ -21,9 +20,7 @@ const (
 )
 
 // AddToQueue adds the given payload to the queue of MAC commands
-// to send to the node. Note that the queue is bound to the node-session, since
-// all mac operations are reset after a re-join of the node.
-// TODO: refactor so that identifier is the DevEUI.
+// to send to the node.
 func AddToQueue(p *redis.Pool, pl QueueItem) error {
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
@@ -34,43 +31,36 @@ func AddToQueue(p *redis.Pool, pl QueueItem) error {
 	c := p.Get()
 	defer c.Close()
 
-	ns, err := session.GetNodeSessionByDevEUI(p, pl.DevEUI)
-	if err != nil {
-		return fmt.Errorf("get node-session for node %s error: %s", pl.DevEUI, err)
-	}
-
 	exp := int64(common.NodeSessionTTL) / int64(time.Millisecond)
-	key := fmt.Sprintf(queueTempl, ns.DevAddr)
+	key := fmt.Sprintf(queueTempl, pl.DevEUI)
 
 	c.Send("MULTI")
 	c.Send("RPUSH", key, buf.Bytes())
 	c.Send("PEXPIRE", key, exp)
-	_, err = c.Do("EXEC")
+	_, err := c.Do("EXEC")
 
 	if err != nil {
 		return fmt.Errorf("add mac-payload to tx queue for node %s error: %s", pl.DevEUI, err)
 	}
 	log.WithFields(log.Fields{
 		"dev_eui":    pl.DevEUI,
-		"dev_addr":   ns.DevAddr,
 		"frmpayload": pl.FRMPayload,
 		"command":    hex.EncodeToString(pl.Data),
 	}).Info("mac-payload added to tx queue")
 	return nil
 }
 
-// ReadQueue reads the full mac-payload queue for the given device address.
-// TODO: refactor so that the identifier is the DevEUI.
-func ReadQueue(p *redis.Pool, devAddr lorawan.DevAddr) ([]QueueItem, error) {
+// ReadQueue reads the full mac-payload queue for the given devEUI.
+func ReadQueue(p *redis.Pool, devEUI lorawan.EUI64) ([]QueueItem, error) {
 	var out []QueueItem
 
 	c := p.Get()
 	defer c.Close()
 
-	key := fmt.Sprintf(queueTempl, devAddr)
+	key := fmt.Sprintf(queueTempl, devEUI)
 	values, err := redis.Values(c.Do("LRANGE", key, 0, -1))
 	if err != nil {
-		return nil, fmt.Errorf("get mac-payload from tx queue for devaddr %s error: %s", devAddr, err)
+		return nil, fmt.Errorf("get mac-payload from tx queue for deveui %s error: %s", devEUI, err)
 	}
 
 	for _, value := range values {
@@ -82,11 +72,24 @@ func ReadQueue(p *redis.Pool, devAddr lorawan.DevAddr) ([]QueueItem, error) {
 		var pl QueueItem
 		err = gob.NewDecoder(bytes.NewReader(b)).Decode(&pl)
 		if err != nil {
-			return nil, fmt.Errorf("decode mac-payload for devaddr %s error: %s", devAddr, err)
+			return nil, fmt.Errorf("decode mac-payload for deveui %s error: %s", devEUI, err)
 		}
 		out = append(out, pl)
 	}
 	return out, nil
+}
+
+// FlushQueue flushes the mac-payload queue for the given devEUI.
+func FlushQueue(p *redis.Pool, devEUI lorawan.EUI64) error {
+	c := p.Get()
+	defer c.Close()
+
+	key := fmt.Sprintf(queueTempl, devEUI)
+	_, err := redis.Int(c.Do("DEL", key))
+	if err != nil {
+		return fmt.Errorf("flush queue error: %s", err)
+	}
+	return nil
 }
 
 // FilterItems filters the given slice of MACPayload elements based
@@ -108,7 +111,7 @@ func FilterItems(payloads []QueueItem, frmPayload bool, maxBytes int) []QueueIte
 
 // DeleteQueueItem deletes the given mac-command from the tx queue
 // of the given device address.
-func DeleteQueueItem(p *redis.Pool, devAddr lorawan.DevAddr, pl QueueItem) error {
+func DeleteQueueItem(p *redis.Pool, devEUI lorawan.EUI64, pl QueueItem) error {
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
 	if err := enc.Encode(pl); err != nil {
@@ -118,20 +121,19 @@ func DeleteQueueItem(p *redis.Pool, devAddr lorawan.DevAddr, pl QueueItem) error
 	c := p.Get()
 	defer c.Close()
 
-	key := fmt.Sprintf(queueTempl, devAddr)
+	key := fmt.Sprintf(queueTempl, devEUI)
 	val, err := redis.Int(c.Do("LREM", key, 0, buf.Bytes()))
 	if err != nil {
-		return fmt.Errorf("delete mac-payload from tx queue for devaddr %s error: %s", devAddr, err)
+		return fmt.Errorf("delete mac-payload from tx queue for deveui %s error: %s", devEUI, err)
 	}
 
 	if val == 0 {
-		return fmt.Errorf("mac-command %X not in tx queue for devaddr %s", pl.Data, devAddr)
+		return fmt.Errorf("mac-command %X not in tx queue for deveui %s", pl.Data, devEUI)
 	}
 
 	log.WithFields(log.Fields{
-		"dev_eui":  pl.DevEUI,
-		"dev_addr": devAddr,
-		"command":  hex.EncodeToString(pl.Data),
+		"dev_eui": pl.DevEUI,
+		"command": hex.EncodeToString(pl.Data),
 	}).Info("mac-payload removed from tx queue")
 	return nil
 }

--- a/internal/maccommand/queue_test.go
+++ b/internal/maccommand/queue_test.go
@@ -37,16 +37,16 @@ func TestQueue(t *testing.T) {
 				So(AddToQueue(p, b), ShouldBeNil)
 
 				Convey("Then reading the queue returns both mac-payloads in the correct order", func() {
-					payloads, err := ReadQueue(p, ns.DevAddr)
+					payloads, err := ReadQueue(p, ns.DevEUI)
 					So(err, ShouldBeNil)
 					So(payloads, ShouldResemble, []QueueItem{a, b})
 				})
 
 				Convey("When deleting mac-command a", func() {
-					So(DeleteQueueItem(p, ns.DevAddr, a), ShouldBeNil)
+					So(DeleteQueueItem(p, ns.DevEUI, a), ShouldBeNil)
 
 					Convey("Then only mac-command b is in the queue", func() {
-						payloads, err := ReadQueue(p, ns.DevAddr)
+						payloads, err := ReadQueue(p, ns.DevEUI)
 						So(err, ShouldBeNil)
 						So(payloads, ShouldResemble, []QueueItem{b})
 					})

--- a/internal/maccommand/queue_test.go
+++ b/internal/maccommand/queue_test.go
@@ -22,7 +22,7 @@ func TestQueue(t *testing.T) {
 				DevAddr: [4]byte{1, 2, 3, 4},
 				DevEUI:  [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
 			}
-			So(session.CreateNodeSession(p, ns), ShouldBeNil)
+			So(session.SaveNodeSession(p, ns), ShouldBeNil)
 
 			Convey("When adding mac-command a and b to the queue", func() {
 				a := QueueItem{

--- a/internal/migration/node_session.go
+++ b/internal/migration/node_session.go
@@ -1,0 +1,69 @@
+package migration
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/brocaar/loraserver/internal/session"
+	"github.com/garyburd/redigo/redis"
+)
+
+// MigrateNodeSessionDevAddrDevEUI migrates the node-sessions from DevAddr to
+// DevEUI identifier.
+func MigrateNodeSessionDevAddrDevEUI(p *redis.Pool) error {
+	c := p.Get()
+	defer c.Close()
+
+	keys, err := redis.Strings(c.Do("KEYS", "node_session_????????")) // only match DevAddr (e.g. 01020304)
+	if err != nil {
+		return fmt.Errorf("get keys error: %s", err)
+	}
+
+	var errCount int
+
+	for _, key := range keys {
+		if err := migrateNodeSession(p, key); err != nil {
+			log.WithField("key", key).Errorf("migrate node-session error: %s", err)
+			errCount++
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"migrated": len(keys) - errCount,
+		"errors":   errCount,
+	}).Infof("migrated node-sessions to new format")
+	return nil
+}
+
+func migrateNodeSession(p *redis.Pool, key string) error {
+	var ns session.NodeSession
+
+	c := p.Get()
+	defer c.Close()
+
+	// get node-session from old key
+	val, err := redis.Bytes(c.Do("GET", key))
+	if err != nil {
+		return fmt.Errorf("get key error: %s", err)
+	}
+	err = gob.NewDecoder(bytes.NewReader(val)).Decode(&ns)
+	if err != nil {
+		return fmt.Errorf("decode node-session error: %s", err)
+	}
+
+	// save node-session (using new key layout)
+	err = session.SaveNodeSession(p, ns)
+	if err != nil {
+		return fmt.Errorf("save node-session error: %s", err)
+	}
+
+	// delete the old key
+	_, err = redis.Int(c.Do("DEL", key))
+	if err != nil {
+		return fmt.Errorf("delete key error: %s", err)
+	}
+
+	return nil
+}

--- a/internal/models/packets.go
+++ b/internal/models/packets.go
@@ -12,6 +12,7 @@ const maxSNRForSort = 5.0
 // RXPacket defines a received PHYPayload together with its rx metadata
 // (rx information from all the receiving gateways).
 type RXPacket struct {
+	DevEUI     lorawan.EUI64
 	PHYPayload lorawan.PHYPayload
 	RXInfoSet  RXInfoSet
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -50,10 +50,19 @@ func ValidateAndGetFullFCntUp(n NodeSession, fCntUp uint32) (uint32, bool) {
 	return 0, false
 }
 
-// CreateNodeSession does the same as SaveNodeSession.
-// TODO: remove this function as it is redundant
-func CreateNodeSession(p *redis.Pool, s NodeSession) error {
-	return SaveNodeSession(p, s)
+// NodeSessionExists returns a bool indicating if a node session exist.
+func NodeSessionExists(p *redis.Pool, devEUI lorawan.EUI64) (bool, error) {
+	c := p.Get()
+	defer c.Close()
+
+	r, err := redis.Int(c.Do("EXISTS", fmt.Sprintf(nodeSessionKeyTempl, devEUI)))
+	if err != nil {
+		return false, fmt.Errorf("get node-session key exists error: %s", err)
+	}
+	if r == 1 {
+		return true, nil
+	}
+	return false, nil
 }
 
 // SaveNodeSession saves the node session. Note that the session will automatically

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -20,7 +20,6 @@ const (
 
 // GetRandomDevAddr returns a random free DevAddr. Note that the 7 MSB will be
 // set to the NwkID (based on the configured NetID).
-// TODO: handle collission with retry?
 func GetRandomDevAddr(p *redis.Pool, netID lorawan.NetID) (lorawan.DevAddr, error) {
 	var d lorawan.DevAddr
 	b := make([]byte, len(d))
@@ -31,17 +30,6 @@ func GetRandomDevAddr(p *redis.Pool, netID lorawan.NetID) (lorawan.DevAddr, erro
 	d[0] = d[0] & 1                    // zero out 7 msb
 	d[0] = d[0] ^ (netID.NwkID() << 1) // set 7 msb to NwkID
 
-	c := p.Get()
-	defer c.Close()
-
-	key := "node_session_" + d.String()
-	val, err := redis.Int(c.Do("EXISTS", key))
-	if err != nil {
-		return lorawan.DevAddr{}, fmt.Errorf("test DevAddr %s exist error: %s", d, err)
-	}
-	if val == 1 {
-		return lorawan.DevAddr{}, fmt.Errorf("DevAddr %s already exists", d)
-	}
 	return d, nil
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -102,7 +102,7 @@ func TestNodeSession(t *testing.T) {
 			Convey("When getting a non-existing NodeSession", func() {
 				_, err := GetNodeSession(p, ns.DevAddr)
 				Convey("Then an error is returned", func() {
-					So(err, ShouldResemble, errors.New("get node-session for DevAddr 01020304 error: redigo: nil returned"))
+					So(err, ShouldResemble, errors.New("node-session for 01020304 does not exist"))
 				})
 			})
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -106,6 +106,15 @@ func TestNodeSession(t *testing.T) {
 				})
 			})
 
+			Convey("When checking if a non-existing NodeSession exists", func() {
+				exists, err := NodeSessionExists(p, ns.DevEUI)
+				So(err, ShouldBeNil)
+
+				Convey("Then false is returned", func() {
+					So(exists, ShouldBeFalse)
+				})
+			})
+
 			Convey("When saving the NodeSession", func() {
 				So(SaveNodeSession(p, ns), ShouldBeNil)
 
@@ -119,6 +128,15 @@ func TestNodeSession(t *testing.T) {
 					ns2, err := GetNodeSessionByDevEUI(p, ns.DevEUI)
 					So(err, ShouldBeNil)
 					So(ns2, ShouldResemble, ns)
+				})
+
+				Convey("When checking if a NodeSession exists", func() {
+					exists, err := NodeSessionExists(p, ns.DevEUI)
+					So(err, ShouldBeNil)
+
+					Convey("Then true is returned", func() {
+						So(exists, ShouldBeTrue)
+					})
 				})
 			})
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -118,10 +118,11 @@ func TestNodeSession(t *testing.T) {
 			Convey("When saving the NodeSession", func() {
 				So(SaveNodeSession(p, ns), ShouldBeNil)
 
-				Convey("Then when getting the NodeSession, the same data is returned", func() {
-					ns2, err := GetNodeSession(p, ns.DevAddr)
+				Convey("Then when getting the NodeSessions for its DevAddr, it contains the NodeSession", func() {
+					sessions, err := GetNodeSessionsForDevAddr(p, ns.DevAddr)
 					So(err, ShouldBeNil)
-					So(ns2, ShouldResemble, ns)
+					So(sessions, ShouldHaveLength, 1)
+					So(sessions[0], ShouldResemble, ns)
 				})
 
 				Convey("Then the session can be retrieved by it's DevEUI", func() {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -173,3 +173,125 @@ func TestNodeSession(t *testing.T) {
 		})
 	})
 }
+
+func TestGetNodeSessionForPHYPayload(t *testing.T) {
+	conf := test.GetConfig()
+
+	Convey("Given a clean Redis database with a set of node-sessions for the same DevAddr", t, func() {
+		p := common.NewRedisPool(conf.RedisURL)
+		test.MustFlushRedis(p)
+
+		devAddr := lorawan.DevAddr{1, 2, 3, 4}
+
+		nodeSessions := []NodeSession{
+			{
+				DevAddr:   devAddr,
+				DevEUI:    lorawan.EUI64{1, 1, 1, 1, 1, 1, 1, 1},
+				NwkSKey:   lorawan.AES128Key{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+				FCntUp:    100,
+				RelaxFCnt: true,
+			},
+			{
+				DevAddr:   devAddr,
+				DevEUI:    lorawan.EUI64{2, 2, 2, 2, 2, 2, 2, 2},
+				NwkSKey:   lorawan.AES128Key{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+				FCntUp:    200,
+				RelaxFCnt: false,
+			},
+		}
+		for _, ns := range nodeSessions {
+			So(SaveNodeSession(p, ns), ShouldBeNil)
+		}
+
+		Convey("Given a set of tests", func() {
+			testTable := []struct {
+				Name           string
+				DevAddr        lorawan.DevAddr
+				NwkSKey        lorawan.AES128Key
+				FCnt           uint32
+				ExpectedDevEUI lorawan.EUI64
+				ExpectedFCntUp uint32
+				ExpectedError  error
+			}{
+				{
+					Name:           "matching DevEUI 0101010101010101",
+					DevAddr:        devAddr,
+					NwkSKey:        nodeSessions[0].NwkSKey,
+					FCnt:           nodeSessions[0].FCntUp,
+					ExpectedFCntUp: nodeSessions[0].FCntUp,
+					ExpectedDevEUI: nodeSessions[0].DevEUI,
+				},
+				{
+					Name:           "matching DevEUI 0202020202020202",
+					DevAddr:        devAddr,
+					NwkSKey:        nodeSessions[1].NwkSKey,
+					FCnt:           nodeSessions[1].FCntUp,
+					ExpectedFCntUp: nodeSessions[1].FCntUp,
+					ExpectedDevEUI: nodeSessions[1].DevEUI,
+				},
+				{
+					Name:           "matching DevEUI 0101010101010101 with frame counter reset",
+					DevAddr:        devAddr,
+					NwkSKey:        nodeSessions[0].NwkSKey,
+					FCnt:           0,
+					ExpectedFCntUp: 0, // has been reset
+					ExpectedDevEUI: nodeSessions[0].DevEUI,
+				},
+				{
+					Name:          "matching DevEUI 0202020202020202 with invalid frame counter",
+					DevAddr:       devAddr,
+					NwkSKey:       nodeSessions[1].NwkSKey,
+					FCnt:          0,
+					ExpectedError: errors.New("node-session does not exist or invalid fcnt or mic"),
+				},
+				{
+					Name:          "invalid DevAddr",
+					DevAddr:       lorawan.DevAddr{1, 1, 1, 1},
+					NwkSKey:       nodeSessions[0].NwkSKey,
+					FCnt:          nodeSessions[0].FCntUp,
+					ExpectedError: errors.New("node-session does not exist or invalid fcnt or mic"),
+				},
+				{
+					Name:          "invalid NwkSKey",
+					DevAddr:       nodeSessions[0].DevAddr,
+					NwkSKey:       lorawan.AES128Key{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+					FCnt:          nodeSessions[0].FCntUp,
+					ExpectedError: errors.New("node-session does not exist or invalid fcnt or mic"),
+				},
+			}
+
+			for i, test := range testTable {
+				Convey(fmt.Sprintf("Testing: %s [%d]", test.Name, i), func() {
+					phy := lorawan.PHYPayload{
+						MHDR: lorawan.MHDR{
+							MType: lorawan.UnconfirmedDataUp,
+							Major: lorawan.LoRaWANR1,
+						},
+						MACPayload: &lorawan.MACPayload{
+							FHDR: lorawan.FHDR{
+								DevAddr: test.DevAddr,
+								FCtrl:   lorawan.FCtrl{},
+								FCnt:    test.FCnt,
+							},
+						},
+					}
+					So(phy.SetMIC(test.NwkSKey), ShouldBeNil)
+
+					ns, err := GetNodeSessionForPHYPayload(p, phy)
+					So(err, ShouldResemble, test.ExpectedError)
+					if test.ExpectedError != nil {
+						return
+					}
+
+					// "refresh" the ns, to test if the FCnt has been updated
+					// in case of a frame counter reset
+					ns, err = GetNodeSessionByDevEUI(p, ns.DevEUI)
+					So(err, ShouldBeNil)
+
+					So(ns.DevEUI, ShouldResemble, test.ExpectedDevEUI)
+					So(ns.FCntUp, ShouldEqual, test.ExpectedFCntUp)
+				})
+			}
+		})
+	})
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -100,9 +100,9 @@ func TestNodeSession(t *testing.T) {
 			}
 
 			Convey("When getting a non-existing NodeSession", func() {
-				_, err := GetNodeSession(p, ns.DevAddr)
+				_, err := GetNodeSession(p, ns.DevEUI)
 				Convey("Then an error is returned", func() {
-					So(err, ShouldResemble, errors.New("node-session for 01020304 does not exist"))
+					So(err, ShouldResemble, errors.New("get node-session 0102030405060708 error: redigo: nil returned"))
 				})
 			})
 
@@ -126,7 +126,7 @@ func TestNodeSession(t *testing.T) {
 				})
 
 				Convey("Then the session can be retrieved by it's DevEUI", func() {
-					ns2, err := GetNodeSessionByDevEUI(p, ns.DevEUI)
+					ns2, err := GetNodeSession(p, ns.DevEUI)
 					So(err, ShouldBeNil)
 					So(ns2, ShouldResemble, ns)
 				})
@@ -285,7 +285,7 @@ func TestGetNodeSessionForPHYPayload(t *testing.T) {
 
 					// "refresh" the ns, to test if the FCnt has been updated
 					// in case of a frame counter reset
-					ns, err = GetNodeSessionByDevEUI(p, ns.DevEUI)
+					ns, err = GetNodeSession(p, ns.DevEUI)
 					So(err, ShouldBeNil)
 
 					So(ns.DevEUI, ShouldResemble, test.ExpectedDevEUI)

--- a/internal/testsuite/class_c_test.go
+++ b/internal/testsuite/class_c_test.go
@@ -275,7 +275,7 @@ func TestClassCScenarios(t *testing.T) {
 					So(err, ShouldResemble, t.ExpectedPushDataDownError)
 
 					Convey("Then the frame-counters are as expected", func() {
-						sess, err := session.GetNodeSessionByDevEUI(ctx.RedisPool, t.NodeSession.DevEUI)
+						sess, err := session.GetNodeSession(ctx.RedisPool, t.NodeSession.DevEUI)
 						So(err, ShouldBeNil)
 						So(sess.FCntUp, ShouldEqual, t.ExpectedFCntUp)
 						So(sess.FCntDown, ShouldEqual, t.ExpectedFCntDown)

--- a/internal/testsuite/class_c_test.go
+++ b/internal/testsuite/class_c_test.go
@@ -292,7 +292,7 @@ func TestClassCScenarios(t *testing.T) {
 					}
 
 					Convey("Then the mac-command queue contains the expected items", func() {
-						items, err := maccommand.ReadQueue(ctx.RedisPool, t.NodeSession.DevAddr)
+						items, err := maccommand.ReadQueue(ctx.RedisPool, t.NodeSession.DevEUI)
 						So(err, ShouldBeNil)
 						So(items, ShouldResemble, t.ExpectedMACCommandQueue)
 					})

--- a/internal/testsuite/class_c_test.go
+++ b/internal/testsuite/class_c_test.go
@@ -219,7 +219,7 @@ func TestClassCScenarios(t *testing.T) {
 						FPort:     10,
 						FCnt:      5,
 					},
-					ExpectedPushDataDownError: grpc.Errorf(codes.Unknown, "get node-session pointer for node 0101010101010101 error: redigo: nil returned"),
+					ExpectedPushDataDownError: grpc.Errorf(codes.Unknown, "get node-session 0101010101010101 error: redigo: nil returned"),
 					ExpectedFCntUp:            8,
 					ExpectedFCntDown:          5,
 				},
@@ -263,7 +263,7 @@ func TestClassCScenarios(t *testing.T) {
 					}
 
 					// create node-session
-					So(session.CreateNodeSession(ctx.RedisPool, t.NodeSession), ShouldBeNil)
+					So(session.SaveNodeSession(ctx.RedisPool, t.NodeSession), ShouldBeNil)
 
 					// mac mac-command queue items
 					for _, qi := range t.MACCommandQueue {

--- a/internal/testsuite/otaa_test.go
+++ b/internal/testsuite/otaa_test.go
@@ -208,7 +208,7 @@ func runOTAATests(ctx common.Context, tests []otaaTestCase) {
 			})
 
 			Convey("Then the expected RXInfoSet has been added to the node-session", func() {
-				ns, err := session.GetNodeSessionByDevEUI(ctx.RedisPool, lorawan.EUI64{2, 2, 3, 4, 5, 6, 7, 8})
+				ns, err := session.GetNodeSession(ctx.RedisPool, lorawan.EUI64{2, 2, 3, 4, 5, 6, 7, 8})
 				So(err, ShouldBeNil)
 				So(ns.LastRXInfoSet, ShouldResemble, []gw.RXInfo{t.RXInfo})
 			})

--- a/internal/testsuite/uplink_test.go
+++ b/internal/testsuite/uplink_test.go
@@ -1643,7 +1643,7 @@ func runUplinkTests(ctx common.Context, tests []uplinkTestCase) {
 			ctx.Application.(*test.ApplicationClient).GetDataDownErr = t.ApplicationGetDataDownError
 
 			// populate session and queues
-			So(session.CreateNodeSession(ctx.RedisPool, t.NodeSession), ShouldBeNil)
+			So(session.SaveNodeSession(ctx.RedisPool, t.NodeSession), ShouldBeNil)
 			for _, pl := range t.MACCommandQueue {
 				So(maccommand.AddToQueue(ctx.RedisPool, pl), ShouldBeNil)
 			}

--- a/internal/testsuite/uplink_test.go
+++ b/internal/testsuite/uplink_test.go
@@ -1750,7 +1750,7 @@ func runUplinkTests(ctx common.Context, tests []uplinkTestCase) {
 
 			// queue validations
 			Convey("Then the mac-command queue is as expected", func() {
-				macQueue, err := maccommand.ReadQueue(ctx.RedisPool, t.NodeSession.DevAddr)
+				macQueue, err := maccommand.ReadQueue(ctx.RedisPool, t.NodeSession.DevEUI)
 				So(err, ShouldBeNil)
 				So(macQueue, ShouldResemble, t.ExpectedMACCommandQueue)
 			})

--- a/internal/testsuite/uplink_test.go
+++ b/internal/testsuite/uplink_test.go
@@ -1734,7 +1734,7 @@ func runUplinkTests(ctx common.Context, tests []uplinkTestCase) {
 
 			// node session validations
 			Convey("Then the frame-counters are as expected", func() {
-				ns, err := session.GetNodeSessionByDevEUI(ctx.RedisPool, t.NodeSession.DevEUI)
+				ns, err := session.GetNodeSession(ctx.RedisPool, t.NodeSession.DevEUI)
 				So(err, ShouldBeNil)
 				So(ns.FCntDown, ShouldEqual, t.ExpectedFCntDown)
 				So(ns.FCntUp, ShouldEqual, t.ExpectedFCntUp)
@@ -1742,7 +1742,7 @@ func runUplinkTests(ctx common.Context, tests []uplinkTestCase) {
 
 			// ADR variables validations
 			Convey("Then the TXPower and NbTrans are as expected", func() {
-				ns, err := session.GetNodeSessionByDevEUI(ctx.RedisPool, t.NodeSession.DevEUI)
+				ns, err := session.GetNodeSession(ctx.RedisPool, t.NodeSession.DevEUI)
 				So(err, ShouldBeNil)
 				So(ns.TXPower, ShouldEqual, t.ExpectedTXPower)
 				So(ns.NbTrans, ShouldEqual, t.ExpectedNbTrans)
@@ -1757,7 +1757,7 @@ func runUplinkTests(ctx common.Context, tests []uplinkTestCase) {
 
 			if t.ExpectedHandleRXPacketError == nil {
 				Convey("Then the expected RSInfoSet has been added to the node-session", func() {
-					ns, err := session.GetNodeSessionByDevEUI(ctx.RedisPool, t.NodeSession.DevEUI)
+					ns, err := session.GetNodeSession(ctx.RedisPool, t.NodeSession.DevEUI)
 					So(err, ShouldBeNil)
 					So(ns.LastRXInfoSet, ShouldResemble, []gw.RXInfo{t.RXInfo})
 				})

--- a/internal/testsuite/uplink_test.go
+++ b/internal/testsuite/uplink_test.go
@@ -337,15 +337,7 @@ func TestUplinkScenarios(t *testing.T) {
 					},
 					ExpectedFCntUp:              8,
 					ExpectedFCntDown:            5,
-					ExpectedHandleRXPacketError: errors.New("invalid FCnt or too many dropped frames"),
-					ExpectedApplicationHandleErrors: []as.HandleErrorRequest{
-						{
-							AppEUI: ns.AppEUI[:],
-							DevEUI: ns.DevEUI[:],
-							Type:   as.ErrorType_DATA_UP_FCNT,
-							Error:  "invalid FCnt or too many dropped frames (server_fcnt: 8, packet_fcnt: 7)",
-						},
-					},
+					ExpectedHandleRXPacketError: errors.New("get node-session error: node-session does not exist or invalid fcnt or mic"),
 				},
 				{
 					Name:        "the mic is invalid",
@@ -367,15 +359,7 @@ func TestUplinkScenarios(t *testing.T) {
 					},
 					ExpectedFCntUp:              8,
 					ExpectedFCntDown:            5,
-					ExpectedHandleRXPacketError: errors.New("invalid MIC"),
-					ExpectedApplicationHandleErrors: []as.HandleErrorRequest{
-						{
-							AppEUI: ns.AppEUI[:],
-							DevEUI: ns.DevEUI[:],
-							Type:   as.ErrorType_DATA_UP_MIC,
-							Error:  "invalid MIC",
-						},
-					},
+					ExpectedHandleRXPacketError: errors.New("get node-session error: node-session does not exist or invalid fcnt or mic"),
 				},
 			}
 
@@ -436,15 +420,7 @@ func TestUplinkScenarios(t *testing.T) {
 					},
 					ExpectedFCntUp:              8,
 					ExpectedFCntDown:            5,
-					ExpectedHandleRXPacketError: errors.New("invalid FCnt or too many dropped frames"),
-					ExpectedApplicationHandleErrors: []as.HandleErrorRequest{
-						{
-							AppEUI: ns.AppEUI[:],
-							DevEUI: ns.DevEUI[:],
-							Type:   as.ErrorType_DATA_UP_FCNT,
-							Error:  "invalid FCnt or too many dropped frames (server_fcnt: 8, packet_fcnt: 7)",
-						},
-					},
+					ExpectedHandleRXPacketError: errors.New("get node-session error: node-session does not exist or invalid fcnt or mic"),
 				},
 				{
 					Name:        "the frame-counter is invalid and 0",

--- a/internal/uplink/collect.go
+++ b/internal/uplink/collect.go
@@ -56,8 +56,8 @@ func collectAndCallOnce(p *redis.Pool, rxPacket gw.RXPacket, callback func(packe
 	// this way we can set a really low DeduplicationDelay for testing, without
 	// the risk that the set already expired in redis on read
 	deduplicationTTL := common.DeduplicationDelay * 2
-	if deduplicationTTL < time.Millisecond*100 {
-		deduplicationTTL = time.Millisecond * 100
+	if deduplicationTTL < time.Millisecond*200 {
+		deduplicationTTL = time.Millisecond * 200
 	}
 
 	c.Send("MULTI")

--- a/internal/uplink/data.go
+++ b/internal/uplink/data.go
@@ -43,6 +43,7 @@ func validateAndCollectDataUpRXPacket(ctx common.Context, rxPacket gw.RXPacket) 
 	}
 
 	return collectAndCallOnce(ctx.RedisPool, rxPacket, func(rxPacket models.RXPacket) error {
+		rxPacket.DevEUI = ns.DevEUI
 		return handleCollectedDataUpPackets(ctx, rxPacket)
 	})
 }
@@ -58,7 +59,7 @@ func handleCollectedDataUpPackets(ctx common.Context, rxPacket models.RXPacket) 
 		return fmt.Errorf("expected *lorawan.MACPayload, got: %T", rxPacket.PHYPayload.MACPayload)
 	}
 
-	ns, err := session.GetNodeSession(ctx.RedisPool, macPL.FHDR.DevAddr)
+	ns, err := session.GetNodeSession(ctx.RedisPool, rxPacket.DevEUI)
 	if err != nil {
 		return err
 	}

--- a/internal/uplink/join_request.go
+++ b/internal/uplink/join_request.go
@@ -113,7 +113,7 @@ func handleCollectedJoinRequestPackets(ctx common.Context, rxPacket models.RXPac
 		LastRXInfoSet:      rxPacket.RXInfoSet,
 	}
 
-	if err = session.CreateNodeSession(ctx.RedisPool, ns); err != nil {
+	if err = session.SaveNodeSession(ctx.RedisPool, ns); err != nil {
 		return fmt.Errorf("create node-session error: %s", err)
 	}
 

--- a/internal/uplink/join_request.go
+++ b/internal/uplink/join_request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brocaar/loraserver/api/gw"
 	"github.com/brocaar/loraserver/internal/common"
 	"github.com/brocaar/loraserver/internal/downlink"
+	"github.com/brocaar/loraserver/internal/maccommand"
 	"github.com/brocaar/loraserver/internal/models"
 	"github.com/brocaar/loraserver/internal/session"
 	"github.com/brocaar/lorawan"
@@ -114,7 +115,11 @@ func handleCollectedJoinRequestPackets(ctx common.Context, rxPacket models.RXPac
 	}
 
 	if err = session.SaveNodeSession(ctx.RedisPool, ns); err != nil {
-		return fmt.Errorf("create node-session error: %s", err)
+		return fmt.Errorf("save node-session error: %s", err)
+	}
+
+	if err = maccommand.FlushQueue(ctx.RedisPool, ns.DevEUI); err != nil {
+		return fmt.Errorf("flush mac-command queue error: %s", err)
 	}
 
 	if err = downlink.SendJoinAcceptResponse(ctx, ns, rxPacket, downlinkPHY); err != nil {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ pages:
   - changelog.md
 
 extra:
-  version: '0.14.1'
+  version: '0.15.0'
   github:
     download_release: true
 


### PR DESCRIPTION
Work in progress. See also #56.

- [x] Function which gets node-session based on PHYPayload (DevAddr, FCnt and MIC)
- [x] Implement the above function in code
- [x] Use `DevEUI` for mac-command queue
- [x] Flush mac-queue on (re)activation
- [x] Implement migration tool (old node-session structure -> new structure)