### PR TITLE
Add reconnection options, #184, #183

### DIFF
--- a/internal/backend/gateway/backend.go
+++ b/internal/backend/gateway/backend.go
@@ -42,6 +42,7 @@ func NewBackend(p *redis.Pool, server, username, password string) (backend.Gatew
 	opts.SetPassword(password)
 	opts.SetOnConnectHandler(b.onConnected)
 	opts.SetConnectionLostHandler(b.onConnectionLost)
+	opts.SetAutoReconnect(true)
 
 	log.WithField("server", server).Info("backend/gateway: connecting to mqtt broker")
 	b.conn = mqtt.NewClient(opts)
@@ -203,5 +204,9 @@ func (b *Backend) onConnected(c mqtt.Client) {
 }
 
 func (b *Backend) onConnectionLost(c mqtt.Client, reason error) {
-	log.Errorf("backend/gateway: mqtt connection error: %s", reason)
+	if c.IsConnected() {
+		log.Warn("backend/gateway: mqtt disconnected, now it is connected again. error: %s", reason)
+	} else {
+		log.Panic("backend/gateway: mqtt disconnected, impossible to reconnect. error: %s", reason)
+	}
 }


### PR DESCRIPTION
I address my concerned about #184  and #183 

Note how I decided to panic in case of impossible reconnection. 

I believe it is the most reasonable thing to do, it may raise an alarm and the supervisor will start to restart the software.

This changes, if approved, should be done also to the lora-app-server and the lora-gateway-bridge

Cheers,
