### PR TITLE
Database name corrected in docs

### DIFF
--- a/docs/content/install/debian.md
+++ b/docs/content/install/debian.md
@@ -30,7 +30,7 @@ Within the the PostgreSQL prompt, enter the following queries:
 create role loraserver_ns with login password 'dbpassword';
 
 -- create the loraserver_ns database
-create database loraserver_ns with owner loraserver_as;
+create database loraserver_ns with owner loraserver_ns;
 
 -- exit the prompt
 \q


### PR DESCRIPTION
There was a little mistyping in the documentation about database creation in psql. This solves it. 