### PR TITLE
Fix a warning message

### DIFF
--- a/internal/storage/device_session.go
+++ b/internal/storage/device_session.go
@@ -262,7 +262,7 @@ func GetDeviceSessionsForDevAddr(p *redis.Pool, devAddr lorawan.DevAddr) ([]Devi
 			log.WithFields(log.Fields{
 				"dev_addr": devAddr,
 				"dev_eui":  devEUI,
-			}).Warning("get device-sessions for dev_addr error: %s", err)
+			}).Warningf("get device-sessions for dev_addr error: %s", err)
 		}
 		items = append(items, s)
 	}


### PR DESCRIPTION
Use `logrus.Warningf` instead of `logrus.Warning` to remove unnecessary `%s`.

Before: `msg="get device-sessions for dev_addr error: %sobject does not exist"`
After: `msg="get device-sessions for dev_addr error: object does not exist"`