### PR TITLE
Fix timezone support in Docker Alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.9-alpine3.6 AS development
 ENV PROJECT_PATH=/go/src/github.com/brocaar/loraserver
 ENV PATH=$PATH:$PROJECT_PATH/build
 
-RUN apk add --no-cache ca-certificates make git bash protobuf
+RUN apk add --no-cache ca-certificates tzdata make git bash protobuf
 
 RUN mkdir -p $PROJECT_PATH
 COPY . $PROJECT_PATH
@@ -15,6 +15,6 @@ RUN make
 FROM alpine:latest AS production
 
 WORKDIR /root/
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates tzdata
 COPY --from=development /go/src/github.com/brocaar/loraserver/build/loraserver .
 ENTRYPOINT ["./loraserver"]

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -3,7 +3,7 @@ FROM golang:1.9-alpine3.6
 ENV PROJECT_PATH=/go/src/github.com/brocaar/loraserver
 ENV PATH=$PATH:$PROJECT_PATH/build
 
-RUN apk add --no-cache ca-certificates make git bash protobuf alpine-sdk ruby ruby-dev libffi-dev
+RUN apk add --no-cache ca-certificates tzdata make git bash protobuf alpine-sdk ruby ruby-dev libffi-dev
 RUN gem install --no-ri --no-rdoc fpm
 
 RUN mkdir -p $PROJECT_PATH


### PR DESCRIPTION
In docker alpine/loraserver images, tzdata package must be installed to add full support to Timezone option like Europe/Amsterdam in loraserver configuration.