### PR TITLE
Fix typo in pubsub key of device frame log

### DIFF
--- a/internal/framelog/framelog.go
+++ b/internal/framelog/framelog.go
@@ -19,8 +19,8 @@ import (
 const (
 	gatewayFrameLogUplinkPubSubKeyTempl   = "lora:ns:gw:%s:pubsub:frame:uplink"
 	gatewayFrameLogDownlinkPubSubKeyTempl = "lora:ns:gw:%s:pubsub:frame:downlink"
-	deviceFrameLogUplinkPubSubKeyTempl    = "lora:ns:device:%d:pubsub:frame:uplink"
-	deviceFrameLogDownlinkPubSubKeyTempl  = "lora:ns:device:%d:pubsub:frame:downlink"
+	deviceFrameLogUplinkPubSubKeyTempl    = "lora:ns:device:%s:pubsub:frame:uplink"
+	deviceFrameLogDownlinkPubSubKeyTempl  = "lora:ns:device:%s:pubsub:frame:downlink"
 )
 
 // UplinkFrameLog contains the details of an uplink frame.


### PR DESCRIPTION
Past: `lora:ns:device:[01 23 45 67 89 100 101 102]:pubsub:frame:uplink`
After: `lora:ns:device:0123456789abcdef:pubsub:frame:uplink`