### PR TITLE
Allow empty Lora packets to be published to the app server.

### DIFF
--- a/internal/uplink/data/data.go
+++ b/internal/uplink/data/data.go
@@ -266,7 +266,7 @@ func handleFRMPayloadMACCommands(ctx *dataContext) error {
 }
 
 func sendFRMPayloadToApplicationServer(ctx *dataContext) error {
-	if ctx.MACPayload.FPort == nil || (ctx.MACPayload.FPort != nil && *ctx.MACPayload.FPort == 0) {
+	if ctx.MACPayload.FPort != nil && *ctx.MACPayload.FPort == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
This patch (along with the corresponding changes made to the lora-app-server at https://github.com/brocaar/lora-app-server/pull/240) allow empty Lora packets to be forwarded on to the app server and published.

It is possible to send a perfectly valid Lora packet that has neither payload nor fport. An example of this can be seen in [Laird Sentrius RS1xx series of devices](https://www.lairdtech.com/products/rs1xx-lora-sensors). After a successful join request, the device sends an empty Lora packet to the server and expects to find the network time in the downlink, otherwise it restarts the join request (see [Sentrius RX1xx User Guide](https://assets.lairdtech.com/home/brandworld/files/Sentrius%20RS1xx%20User%20Guide%20v1_0.pdf) section 6.4). The current implementation of loraserver prevents such empty packets (which don't have an FPort) to be forwarded on to the application server, thus preventing devices such as the RS1xx from being used with this software. This patch fixes this.