### PR TITLE
Modify join and data downlinks to use the board and antenna properties

### DIFF
--- a/internal/downlink/data/data.go
+++ b/internal/downlink/data/data.go
@@ -325,6 +325,8 @@ func getDataTXInfoForRX2(ctx *dataContext) error {
 		return errors.Wrap(err, "get data-rate error")
 	}
 
+	rxInfo := ctx.RXPacket.RXInfoSet[0]
+
 	ctx.TXInfo = gw.TXInfo{
 		MAC:         mac,
 		Immediately: true,
@@ -332,6 +334,8 @@ func getDataTXInfoForRX2(ctx *dataContext) error {
 		Power:       config.C.NetworkServer.Band.Band.GetDownlinkTXPower(ctx.DeviceSession.RX2Frequency),
 		DataRate:    dr,
 		CodeRate:    defaultCodeRate,
+		Board:       rxInfo.Board,
+		Antenna:     rxInfo.Antenna,
 	}
 	ctx.DataRate = int(ctx.DeviceSession.RX2DR)
 
@@ -356,12 +360,16 @@ func setTXInfoForClassB(ctx *dataContext) error {
 		return errors.Wrap(err, "get data-rate error")
 	}
 
+	rxInfo := ctx.RXPacket.RXInfoSet[0]
+
 	ctx.TXInfo = gw.TXInfo{
 		MAC:       mac,
 		Frequency: ctx.DeviceSession.PingSlotFrequency,
 		Power:     config.C.NetworkServer.Band.Band.GetDownlinkTXPower(ctx.DeviceSession.PingSlotFrequency),
 		DataRate:  dr,
 		CodeRate:  defaultCodeRate,
+		Board:     rxInfo.Board,
+		Antenna:   rxInfo.Antenna,
 	}
 	ctx.DataRate = ctx.DeviceSession.PingSlotDR
 
@@ -812,6 +820,8 @@ func getDataDownTXInfoAndDR(ds storage.DeviceSession, lastTXInfo models.TXInfo, 
 	txInfo := gw.TXInfo{
 		MAC:      rxInfo.MAC,
 		CodeRate: lastTXInfo.CodeRate,
+		Board:    rxInfo.Board,
+		Antenna:  rxInfo.Antenna,
 	}
 
 	var timestamp uint32

--- a/internal/downlink/data/data.go
+++ b/internal/downlink/data/data.go
@@ -325,7 +325,13 @@ func getDataTXInfoForRX2(ctx *dataContext) error {
 		return errors.Wrap(err, "get data-rate error")
 	}
 
-	rxInfo := ctx.RXPacket.RXInfoSet[0]
+	var board, antenna int = 0, 0
+
+	if ctx.RXPacket != nil {
+		rxInfo := ctx.RXPacket.RXInfoSet[0]
+		board = rxInfo.Board
+		antenna = rxInfo.Antenna
+	}
 
 	ctx.TXInfo = gw.TXInfo{
 		MAC:         mac,
@@ -334,8 +340,8 @@ func getDataTXInfoForRX2(ctx *dataContext) error {
 		Power:       config.C.NetworkServer.Band.Band.GetDownlinkTXPower(ctx.DeviceSession.RX2Frequency),
 		DataRate:    dr,
 		CodeRate:    defaultCodeRate,
-		Board:       rxInfo.Board,
-		Antenna:     rxInfo.Antenna,
+		Board:       board,
+		Antenna:     antenna,
 	}
 	ctx.DataRate = int(ctx.DeviceSession.RX2DR)
 
@@ -360,7 +366,13 @@ func setTXInfoForClassB(ctx *dataContext) error {
 		return errors.Wrap(err, "get data-rate error")
 	}
 
-	rxInfo := ctx.RXPacket.RXInfoSet[0]
+	var board, antenna int = 0, 0
+
+	if ctx.RXPacket != nil {
+		rxInfo := ctx.RXPacket.RXInfoSet[0]
+		board = rxInfo.Board
+		antenna = rxInfo.Antenna
+	}
 
 	ctx.TXInfo = gw.TXInfo{
 		MAC:       mac,
@@ -368,8 +380,8 @@ func setTXInfoForClassB(ctx *dataContext) error {
 		Power:     config.C.NetworkServer.Band.Band.GetDownlinkTXPower(ctx.DeviceSession.PingSlotFrequency),
 		DataRate:  dr,
 		CodeRate:  defaultCodeRate,
-		Board:     rxInfo.Board,
-		Antenna:   rxInfo.Antenna,
+		Board:     board,
+		Antenna:   antenna,
 	}
 	ctx.DataRate = ctx.DeviceSession.PingSlotDR
 

--- a/internal/downlink/join/join.go
+++ b/internal/downlink/join/join.go
@@ -68,6 +68,8 @@ func getJoinAcceptTXInfo(ctx *joinContext) error {
 	ctx.TXInfo = gw.TXInfo{
 		MAC:      rxInfo.MAC,
 		CodeRate: ctx.RXPacket.TXInfo.CodeRate,
+		Board:    rxInfo.Board,
+		Antenna:  rxInfo.Antenna,
 	}
 
 	var timestamp uint32


### PR DESCRIPTION
This implements issue #340 by modifying the downlink routines for data and join packets to use the Board and Antenna properties of their corresponding RXPackets.

Note: This is not implemented for proprietary messages are their downlink code doesn't make any reference to the RXPacket