### PR TITLE
Replace uses of satori/go.uuid with gofrs/uuid.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1f6d2e8a529e7a05e9efb20b7aca2ce3876d0b3c9e79b3218637e3f7b138651f"
+  digest = "1:1999a8214b5cf01d5a3e71a763714db92f4d7ff96db0e0838be1feb78a4aa11a"
   name = "github.com/brocaar/lorawan"
   packages = [
     ".",
@@ -23,7 +23,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4e8c8dcc6d806023078d11a9bec6a292e40dbce137a3c2eb917de9b2fc013e47"
+  digest = "1:34ba4f73b4f539f5ee3e2aee6399c99b8295b0159b8bb021a78f82b008369edf"
   name = "github.com/eclipse/paho.mqtt.golang"
   packages = [
     ".",
@@ -41,7 +41,7 @@
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:b836c25b7939c6e7bbb2c2e3ebbcf607000792eaf84c2e173328c85bb64ef026"
+  digest = "1:d28347c2e8e3b4db1dc17f8188d997402c59ad85bd33288b5b92515d6d89d072"
   name = "github.com/garyburd/redigo"
   packages = [
     "internal",
@@ -52,7 +52,7 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:5aa861fab3707e89eb00c48826a80706de5c52cc7a5fc5688a9ba422c48de44e"
+  digest = "1:b94bab36a8de2c47e633a8b822bc12cb78eaeaf66a929bcc32b7297de883c02e"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -70,6 +70,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:a528e09bffd7a23a0d2d25a1da6a1fb067ac7b6cfea7fc8cbd58af2750c68e0e"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "dec09d789f3dba190787f8b4454c7d3c936fed9e"
+
+[[projects]]
+  branch = "master"
   digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
   name = "github.com/gopherjs/gopherjs"
   packages = ["js"]
@@ -78,7 +86,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:53dcd08f59897bed5314c025dd57b43af1025c5685e27cd5a1565d7e289450df"
+  digest = "1:ade4a17a74189afeaca389d452a1b20207b6642471548158f488a38da287cf1a"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
@@ -92,7 +100,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5b0a30001d1ff3fbfd92029178ff1d16731f19e886f3b17e6a77989cde9e1441"
+  digest = "1:9d28dd6ad84cf6c3e47e36b50761fb5092922a3ff15e775094d1694cb0deb64e"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -119,7 +127,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:489536052bc7744088c06ea72c3167a1adccfa206056489700daecafdad26a26"
+  digest = "1:db71ee03c191f7f07cb8840e8072bfdef25248108d52d2c529cabb9f0f76a5ae"
   name = "github.com/jacobsa/crypto"
   packages = [
     "cmac",
@@ -130,7 +138,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ca9462277fbf7d2a0cd4e22b7269a9b8ffe0f78a4e18fd6826cb9df90ec01c8a"
+  digest = "1:920a01daad13b3c03edcba925e90c2ed089b9661292350d49f5affa96b5345d2"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
@@ -149,7 +157,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:af81271b2d216c13c4b31a9df3a533f7236e88ba0e8fa371fef7edaef14d9dd4"
+  digest = "1:47315d803e900380830af8fb6c4122ad4c995045fd0b96a6218c804ed60ee65f"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -202,14 +210,6 @@
   revision = "6edbfbd6a369ee82463312ec67b2c92f97a1d4dc"
 
 [[projects]]
-  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
-
-[[projects]]
   digest = "1:6201742366c1518fc5f0df9ccdb4d193fc8a2aef2cc57bf164c9bca23bd5f869"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -218,7 +218,7 @@
   version = "v1.0.4"
 
 [[projects]]
-  digest = "1:8e059ba57bf50718652c005894a680ff47e8201760e9ee658091754daaebd578"
+  digest = "1:268d9458e12861d01186d9cee12870f8586d11de8a5a152f3f95d4c7573e0cb8"
   name = "github.com/smartystreets/assertions"
   packages = [
     ".",
@@ -230,7 +230,7 @@
   version = "1.8.1"
 
 [[projects]]
-  digest = "1:d7b05f2a6c2f3fc4d4d8018ada93d00847d30a0bbbf17d7b385bccad163e68f1"
+  digest = "1:7efd0b2309cdd6468029fa30c808c50a820c9344df07e1a4bbdaf18f282907aa"
   name = "github.com/smartystreets/goconvey"
   packages = [
     "convey",
@@ -242,7 +242,7 @@
   version = "1.6.3"
 
 [[projects]]
-  digest = "1:5acbd68f7ea50fa49d973127d8eee280fed9c6e8db1a197d782d61afed9fe3bb"
+  digest = "1:39da3da7a735176ff518f7a6d8de9e4e03cb760dc7ef0b7b8dae6fc61406295c"
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -262,7 +262,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0c83c5f01c03f8d035e3bee9943d27710d82b4ddf8477570792274b671bf4738"
+  digest = "1:34621b5455af57087bc5006bf8d5428bccd51225472fa58d74b2feace68c739a"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = "NUT"
@@ -302,7 +302,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:95bd62b8ffb48344efc181dc1882a4c67b4c9b6bf0ab24386110ee5dd3a785bc"
+  digest = "1:2934eda910dc36b3e12c2eaa8371322fb30dd4865f8a345a157119c688324673"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -320,7 +320,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b518ec6d041ce66d3452fbf8ccf603e8513ab12359397b1f958e23d72d08a65f"
+  digest = "1:4e67fdd7a13cbdb3c0dff0a7505abbdf4f42b12b27da350d66bffdc700db2899"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -331,7 +331,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a0f29009397dc27c9dc8440f0945d49e5cbb9b72d0b0fc745474d9bfdea2d9f8"
+  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -361,7 +361,7 @@
   revision = "a8101f21cf983e773d0c1133ebc5424792003214"
 
 [[projects]]
-  digest = "1:9f3dd495b7966784f5ca8e08a01228e617581dead1baeb8f0bde88bf4c061206"
+  digest = "1:4fe8befdb2e04f50121183fd62c017aa8f70e09eae083d132060e4274f704f25"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -422,6 +422,7 @@
     "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/google/uuid",
     "github.com/grpc-ecosystem/go-grpc-middleware",
     "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus",
     "github.com/grpc-ecosystem/go-grpc-middleware/tags",
@@ -429,7 +430,6 @@
     "github.com/lib/pq",
     "github.com/pkg/errors",
     "github.com/rubenv/sql-migrate",
-    "github.com/satori/go.uuid",
     "github.com/sirupsen/logrus",
     "github.com/smartystreets/goconvey/convey",
     "github.com/spf13/cobra",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,7 +71,7 @@
 [[projects]]
   branch = "master"
   digest = "1:a528e09bffd7a23a0d2d25a1da6a1fb067ac7b6cfea7fc8cbd58af2750c68e0e"
-  name = "github.com/google/uuid"
+  name = "github.com/gofrs/uuid"
   packages = ["."]
   pruneopts = "NUT"
   revision = "dec09d789f3dba190787f8b4454c7d3c936fed9e"
@@ -422,7 +422,7 @@
     "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
-    "github.com/google/uuid",
+    "github.com/gofrs/uuid",
     "github.com/grpc-ecosystem/go-grpc-middleware",
     "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus",
     "github.com/grpc-ecosystem/go-grpc-middleware/tags",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,14 +23,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:34ba4f73b4f539f5ee3e2aee6399c99b8295b0159b8bb021a78f82b008369edf"
+  digest = "1:4a2f7ee2663631376475da676508b9dc57bc2844d7b8ef27aa4f4c40370bf9d2"
   name = "github.com/eclipse/paho.mqtt.golang"
   packages = [
     ".",
     "packets",
   ]
   pruneopts = "NUT"
-  revision = "750c97f293745e8220737ef933da2ec829d2fddd"
+  revision = "88c4622b8e24c52f64a0caaa28e40b91629bb6e6"
 
 [[projects]]
   digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
@@ -41,15 +41,23 @@
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:d28347c2e8e3b4db1dc17f8188d997402c59ad85bd33288b5b92515d6d89d072"
+  digest = "1:0594af97b2f4cec6554086eeace6597e20a4b69466eb4ada25adf9f4300dddd2"
   name = "github.com/garyburd/redigo"
   packages = [
     "internal",
     "redis",
   ]
   pruneopts = "NUT"
-  revision = "d1ed5c67e5794de818ea85e6b522fda02623a484"
-  version = "v1.4.0"
+  revision = "a69d19351219b6dd56f274f96d85a7014a2ec34e"
+  version = "v1.6.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d8e1fa697a7bc54507f6ddff7699b6a56f009c3ed7267f0d3719d678fdc56dc6"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "540727032f71d0f1ba9a74a8e0216fbb4356e2ed"
 
 [[projects]]
   digest = "1:b94bab36a8de2c47e633a8b822bc12cb78eaeaf66a929bcc32b7297de883c02e"
@@ -70,37 +78,30 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a528e09bffd7a23a0d2d25a1da6a1fb067ac7b6cfea7fc8cbd58af2750c68e0e"
-  name = "github.com/gofrs/uuid"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "dec09d789f3dba190787f8b4454c7d3c936fed9e"
-
-[[projects]]
-  branch = "master"
   digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
   name = "github.com/gopherjs/gopherjs"
   packages = ["js"]
   pruneopts = "NUT"
-  revision = "444abdf920945de5d4a977b572bcc6c674d1e4eb"
+  revision = "0892b62f0d9fb5857760c3cfca837207185117ee"
 
 [[projects]]
   branch = "master"
-  digest = "1:ade4a17a74189afeaca389d452a1b20207b6642471548158f488a38da287cf1a"
+  digest = "1:fdd5eb4503e8d129faf7413aaf6474c49b503e793adcee9be608afc695bf1b76"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
     "logging",
     "logging/logrus",
+    "logging/logrus/ctxlogrus",
     "tags",
     "tags/logrus",
   ]
   pruneopts = "NUT"
-  revision = "d0c54e68681ec7999ac17864470f3bee6521ba2b"
+  revision = "e9c5d9645c437ab1b204cff969a2c0fb16cd4276"
 
 [[projects]]
   branch = "master"
-  digest = "1:9d28dd6ad84cf6c3e47e36b50761fb5092922a3ff15e775094d1694cb0deb64e"
+  digest = "1:11c6c696067d3127ecf332b10f89394d386d9083f82baf71f40f2da31841a009"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -115,7 +116,7 @@
     "json/token",
   ]
   pruneopts = "NUT"
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
@@ -138,14 +139,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:920a01daad13b3c03edcba925e90c2ed089b9661292350d49f5affa96b5345d2"
+  digest = "1:f8670bc82b370c3dd4a64699bc7157cb66bb7c4f43be06edd5e7e4cc134bfa57"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
     "reflectx",
   ]
   pruneopts = "NUT"
-  revision = "de8647470aafe4854c976707c431dbe1eb2822c6"
+  revision = "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849"
 
 [[projects]]
   digest = "1:6ddab442e52381bab82fb6c07ef3f4b565ff7ec4b8fae96d8dd4b8573a460597"
@@ -157,38 +158,38 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:47315d803e900380830af8fb6c4122ad4c995045fd0b96a6218c804ed60ee65f"
+  digest = "1:6415011db6d5f89961c38446f3552c74749462bef94904534c55e3dda1affeb9"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "oid",
   ]
   pruneopts = "NUT"
-  revision = "83612a56d3dd153a94a629cd64925371c9adad78"
+  revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
-  digest = "1:6540c20407c0637773dc6ccfdb9a6790b59d629fb38fa81a0c363e41af4c4c03"
+  digest = "1:d244f8666a838fe6ad70ec8fe77f50ebc29fdc3331a2729ba5886bef8435d10d"
   name = "github.com/magiconair/properties"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "d419a98cdbed11a922bf76f257b7c4be79b50e73"
-  version = "v1.7.4"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4b9dacaf3496e8bd82173b88c38004028a103b03ddd2de15a0a108f04619e00b"
+  digest = "1:5fe20cfe4ef484c237cec9f947b2a6fa90bad4b8610fd014f0e4211e13d82d5d"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "a4e142e9c047c904fa2f1e144d9a84e6133024bc"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
-  digest = "1:13b8f1a2ce177961dc9231606a52f709fab896c565f3988f60a7f6b4e543a902"
+  digest = "1:51ea800cff51752ff68e12e04106f5887b4daec6f9356721238c28019f0b42db"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
@@ -200,25 +201,25 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8125d3f3e31b73d9b6b04ccad828875c541036e0e4bc3a987a8721780503d24e"
+  digest = "1:31ec59331b363458da45d6be29fefd94d07d9393eb402280bf764601ae7cb421"
   name = "github.com/rubenv/sql-migrate"
   packages = [
     ".",
     "sqlparse",
   ]
   pruneopts = "NUT"
-  revision = "6edbfbd6a369ee82463312ec67b2c92f97a1d4dc"
+  revision = "3f452fc0ebebbb784fdab91f7bc79a31dcacab5c"
 
 [[projects]]
-  digest = "1:6201742366c1518fc5f0df9ccdb4d193fc8a2aef2cc57bf164c9bca23bd5f869"
+  digest = "1:b2339e83ce9b5c4f79405f949429a7f68a9a904fed903c672aac1e7ceb7f5f02"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
-  version = "v1.0.4"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
-  digest = "1:268d9458e12861d01186d9cee12870f8586d11de8a5a152f3f95d4c7573e0cb8"
+  digest = "1:1f0b284a6858827de4c27c66b49b2b25df3e16b031c2b57b7892273131e7dd2b"
   name = "github.com/smartystreets/assertions"
   packages = [
     ".",
@@ -226,8 +227,8 @@
     "internal/oglematchers",
   ]
   pruneopts = "NUT"
-  revision = "0b37b35ec7434b77e77a4bb29b79677cced992ea"
-  version = "1.8.1"
+  revision = "7678a5452ebea5b7090a6b163f844c133f523da2"
+  version = "1.8.3"
 
 [[projects]]
   digest = "1:7efd0b2309cdd6468029fa30c808c50a820c9344df07e1a4bbdaf18f282907aa"
@@ -242,31 +243,31 @@
   version = "1.6.3"
 
 [[projects]]
-  digest = "1:39da3da7a735176ff518f7a6d8de9e4e03cb760dc7ef0b7b8dae6fc61406295c"
+  digest = "1:330e9062b308ac597e28485699c02223bd052437a6eed32a173c9227dcb9d95a"
   name = "github.com/spf13/afero"
   packages = [
     ".",
     "mem",
   ]
   pruneopts = "NUT"
-  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
-  version = "v1.0.2"
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:2139901f05c6c9b5d9e5a61d473b9253fff1820562136b0adb802bfee2e0a462"
+  digest = "1:3fa7947ca83b98ae553590d993886e845a4bff19b7b007e869c6e0dd3b9da9cd"
   name = "github.com/spf13/cast"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
-  version = "v1.1.0"
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:34621b5455af57087bc5006bf8d5428bccd51225472fa58d74b2feace68c739a"
+  digest = "1:343d44e06621142ab09ae0c76c1799104cdfddd3ffb445d78b1adf8dc3ffaf3d"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "93959269ad99e80983c9ba742a7e01203a4c0e4f"
+  revision = "7c4570c3ebeb8129a1f7456d0908a8b676b6f9f1"
 
 [[projects]]
   branch = "master"
@@ -277,60 +278,60 @@
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
-  digest = "1:3ab855aa584d08db6541ce99dad60c12bd6a328ecb8a7358363887f85c976347"
+  digest = "1:15e5c398fbd9d2c439b635a08ac161b13d04f0c2aa587fe256b65dc0c3efe8b7"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:3327c8113e7c4c420ea01123c73a5bf9fe79cf9de201d4bf4761a8b0fc5b31a4"
+  digest = "1:8298174246e0007a03be0e1679c3a9f00b204574cdcad698757113730753f745"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5"
+  revision = "d493c32b69b8c6f2377bf30bc4d70267ffbc0793"
 
 [[projects]]
   branch = "master"
-  digest = "1:707ec3bb6ccc1cd330b8789467fa6cd8dad40f63fed028ba777a6c2ca13a9838"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NUT"
-  revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
+  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
-  digest = "1:2934eda910dc36b3e12c2eaa8371322fb30dd4865f8a345a157119c688324673"
+  digest = "1:c158ab109a0f317e5ba6bb20c20cba2333a0bcffdb39319ed34347b1e3d863db"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
+    "internal/socks",
     "internal/timeseries",
-    "lex/httplex",
     "proxy",
     "trace",
     "websocket",
   ]
   pruneopts = "NUT"
-  revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
+  revision = "49c15d80dfbc983ea25246ee959d970efe09ec09"
 
 [[projects]]
   branch = "master"
-  digest = "1:4e67fdd7a13cbdb3c0dff0a7505abbdf4f42b12b27da350d66bffdc700db2899"
+  digest = "1:43a352083eca9cd2a8e74419460d5767885501265cfca9c7204cc085aead1361"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NUT"
-  revision = "fff93fa7cd278d84afc205751523809c464168ab"
+  revision = "bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e"
 
 [[projects]]
-  branch = "master"
   digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
   name = "golang.org/x/text"
   packages = [
@@ -350,18 +351,19 @@
     "unicode/rangetable",
   ]
   pruneopts = "NUT"
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:cd018653a358d4b743a9d3bee89e825521f2ab2f2ec0770164bf7632d8d73ab7"
+  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "NUT"
-  revision = "a8101f21cf983e773d0c1133ebc5424792003214"
+  revision = "daca94659cb50e9f37c1b834680f2e46358f10b0"
 
 [[projects]]
-  digest = "1:4fe8befdb2e04f50121183fd62c017aa8f70e09eae083d132060e4274f704f25"
+  digest = "1:c2d756dba3cf0bc2d50ff9b3e4b80cd327436cf678386a51c8417d084625a51d"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -372,9 +374,14 @@
     "connectivity",
     "credentials",
     "encoding",
-    "grpclb/grpc_lb_v1/messages",
+    "encoding/proto",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -385,11 +392,10 @@
     "stats",
     "status",
     "tap",
-    "transport",
   ]
   pruneopts = "NUT"
-  revision = "7cea4cc846bcf00cbb27595b07da5de875ef7de9"
-  version = "v1.9.1"
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
 
 [[projects]]
   digest = "1:05eff2c4f2ce868b5c9ced8b96607201155a812920eac4d30a85b6b9b72338ce"
@@ -400,12 +406,12 @@
   version = "v1.7.1"
 
 [[projects]]
-  branch = "v2"
-  digest = "1:13e704c08924325be00f96e47e7efe0bfddf0913cdfc237423c83f9b183ff590"
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -417,12 +423,12 @@
     "github.com/brocaar/lorawan/band",
     "github.com/eclipse/paho.mqtt.golang",
     "github.com/garyburd/redigo/redis",
+    "github.com/gofrs/uuid",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes",
     "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
-    "github.com/gofrs/uuid",
     "github.com/grpc-ecosystem/go-grpc-middleware",
     "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus",
     "github.com/grpc-ecosystem/go-grpc-middleware/tags",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@
   name = "github.com/rubenv/sql-migrate"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2.0"
+  branch = "master"
+  name = "github.com/google/uuid"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/google/uuid"
+  name = "github.com/gofrs/uuid"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -102,7 +102,7 @@ func (n *NetworkServerAPI) CreateServiceProfile(ctx context.Context, req *ns.Cre
 	}
 
 	return &ns.CreateServiceProfileResponse{
-		Id: sp.ID[:],
+		Id: sp.ID.Bytes(),
 	}, nil
 }
 
@@ -118,7 +118,7 @@ func (n *NetworkServerAPI) GetServiceProfile(ctx context.Context, req *ns.GetSer
 
 	resp := ns.GetServiceProfileResponse{
 		ServiceProfile: &ns.ServiceProfile{
-			Id:                     sp.ID[:],
+			Id:                     sp.ID.Bytes(),
 			UlRate:                 uint32(sp.ULRate),
 			UlBucketSize:           uint32(sp.ULBucketSize),
 			DlRate:                 uint32(sp.DLRate),
@@ -260,7 +260,7 @@ func (n *NetworkServerAPI) CreateRoutingProfile(ctx context.Context, req *ns.Cre
 	}
 
 	return &ns.CreateRoutingProfileResponse{
-		Id: rp.ID[:],
+		Id: rp.ID.Bytes(),
 	}, nil
 }
 
@@ -276,7 +276,7 @@ func (n *NetworkServerAPI) GetRoutingProfile(ctx context.Context, req *ns.GetRou
 
 	resp := ns.GetRoutingProfileResponse{
 		RoutingProfile: &ns.RoutingProfile{
-			Id:      rp.ID[:],
+			Id:      rp.ID.Bytes(),
 			AsId:    rp.ASID,
 			CaCert:  rp.CACert,
 			TlsCert: rp.TLSCert,
@@ -414,7 +414,7 @@ func (n *NetworkServerAPI) GetDeviceProfile(ctx context.Context, req *ns.GetDevi
 
 	resp := ns.GetDeviceProfileResponse{
 		DeviceProfile: &ns.DeviceProfile{
-			Id:                 dp.ID[:],
+			Id:                 dp.ID.Bytes(),
 			SupportsClassB:     dp.SupportsClassB,
 			ClassBTimeout:      uint32(dp.ClassBTimeout),
 			PingSlotPeriod:     uint32(dp.PingSlotPeriod),
@@ -1075,7 +1075,7 @@ func (n *NetworkServerAPI) CreateGatewayProfile(ctx context.Context, req *ns.Cre
 		return nil, errToRPCError(err)
 	}
 
-	return &ns.CreateGatewayProfileResponse{Id: gc.ID[:]}, nil
+	return &ns.CreateGatewayProfileResponse{Id: gc.ID.Bytes()}, nil
 }
 
 // GetGatewayProfile returns the gateway-profile given an id.
@@ -1090,7 +1090,7 @@ func (n *NetworkServerAPI) GetGatewayProfile(ctx context.Context, req *ns.GetGat
 
 	out := ns.GetGatewayProfileResponse{
 		GatewayProfile: &ns.GatewayProfile{
-			Id: gc.ID[:],
+			Id: gc.ID.Bytes(),
 		},
 	}
 

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -3,9 +3,9 @@ package api
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -102,7 +102,7 @@ func (n *NetworkServerAPI) CreateServiceProfile(ctx context.Context, req *ns.Cre
 	}
 
 	return &ns.CreateServiceProfileResponse{
-		Id: sp.ID.Bytes(),
+		Id: sp.ID[:],
 	}, nil
 }
 
@@ -118,7 +118,7 @@ func (n *NetworkServerAPI) GetServiceProfile(ctx context.Context, req *ns.GetSer
 
 	resp := ns.GetServiceProfileResponse{
 		ServiceProfile: &ns.ServiceProfile{
-			Id:                     sp.ID.Bytes(),
+			Id:                     sp.ID[:],
 			UlRate:                 uint32(sp.ULRate),
 			UlBucketSize:           uint32(sp.ULBucketSize),
 			DlRate:                 uint32(sp.DLRate),
@@ -260,7 +260,7 @@ func (n *NetworkServerAPI) CreateRoutingProfile(ctx context.Context, req *ns.Cre
 	}
 
 	return &ns.CreateRoutingProfileResponse{
-		Id: rp.ID.Bytes(),
+		Id: rp.ID[:],
 	}, nil
 }
 
@@ -276,7 +276,7 @@ func (n *NetworkServerAPI) GetRoutingProfile(ctx context.Context, req *ns.GetRou
 
 	resp := ns.GetRoutingProfileResponse{
 		RoutingProfile: &ns.RoutingProfile{
-			Id:      rp.ID.Bytes(),
+			Id:      rp.ID[:],
 			AsId:    rp.ASID,
 			CaCert:  rp.CACert,
 			TlsCert: rp.TLSCert,
@@ -393,7 +393,7 @@ func (n *NetworkServerAPI) CreateDeviceProfile(ctx context.Context, req *ns.Crea
 	}
 
 	return &ns.CreateDeviceProfileResponse{
-		Id: dp.ID.Bytes(),
+		Id: dp.ID[:],
 	}, nil
 }
 
@@ -414,7 +414,7 @@ func (n *NetworkServerAPI) GetDeviceProfile(ctx context.Context, req *ns.GetDevi
 
 	resp := ns.GetDeviceProfileResponse{
 		DeviceProfile: &ns.DeviceProfile{
-			Id:                 dp.ID.Bytes(),
+			Id:                 dp.ID[:],
 			SupportsClassB:     dp.SupportsClassB,
 			ClassBTimeout:      uint32(dp.ClassBTimeout),
 			PingSlotPeriod:     uint32(dp.PingSlotPeriod),
@@ -1075,7 +1075,7 @@ func (n *NetworkServerAPI) CreateGatewayProfile(ctx context.Context, req *ns.Cre
 		return nil, errToRPCError(err)
 	}
 
-	return &ns.CreateGatewayProfileResponse{Id: gc.ID.Bytes()}, nil
+	return &ns.CreateGatewayProfileResponse{Id: gc.ID[:]}, nil
 }
 
 // GetGatewayProfile returns the gateway-profile given an id.
@@ -1090,7 +1090,7 @@ func (n *NetworkServerAPI) GetGatewayProfile(ctx context.Context, req *ns.GetGat
 
 	out := ns.GetGatewayProfileResponse{
 		GatewayProfile: &ns.GatewayProfile{
-			Id: gc.ID.Bytes(),
+			Id: gc.ID[:],
 		},
 	}
 
@@ -1386,7 +1386,7 @@ func gwToResp(gw storage.Gateway) *ns.GetGatewayResponse {
 	}
 
 	if gw.GatewayProfileID != nil {
-		resp.Gateway.GatewayProfileId = gw.GatewayProfileID.Bytes()
+		resp.Gateway.GatewayProfileId = gw.GatewayProfileID[:]
 	}
 
 	return &resp

--- a/internal/api/network_server.go
+++ b/internal/api/network_server.go
@@ -393,7 +393,7 @@ func (n *NetworkServerAPI) CreateDeviceProfile(ctx context.Context, req *ns.Crea
 	}
 
 	return &ns.CreateDeviceProfileResponse{
-		Id: dp.ID[:],
+		Id: dp.ID.Bytes(),
 	}, nil
 }
 
@@ -1386,7 +1386,7 @@ func gwToResp(gw storage.Gateway) *ns.GetGatewayResponse {
 	}
 
 	if gw.GatewayProfileID != nil {
-		resp.Gateway.GatewayProfileId = gw.GatewayProfileID[:]
+		resp.Gateway.GatewayProfileId = gw.GatewayProfileID.Bytes()
 	}
 
 	return &resp

--- a/internal/api/network_server_test.go
+++ b/internal/api/network_server_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/google/uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/internal/api/network_server_test.go
+++ b/internal/api/network_server_test.go
@@ -430,9 +430,9 @@ func TestNetworkServerAPI(t *testing.T) {
 				_, err := api.CreateDevice(ctx, &ns.CreateDeviceRequest{
 					Device: &ns.Device{
 						DevEui:           devEUI[:],
-						DeviceProfileId:  dp.ID[:],
-						ServiceProfileId: sp.ID[:],
-						RoutingProfileId: rp.ID[:],
+						DeviceProfileId:  dp.ID.Bytes(),
+						ServiceProfileId: sp.ID.Bytes(),
+						RoutingProfileId: rp.ID.Bytes(),
 						SkipFCntCheck:    true,
 					},
 				})
@@ -445,9 +445,9 @@ func TestNetworkServerAPI(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(resp.Device, ShouldResemble, &ns.Device{
 						DevEui:           devEUI[:],
-						DeviceProfileId:  dp.ID[:],
-						ServiceProfileId: sp.ID[:],
-						RoutingProfileId: rp.ID[:],
+						DeviceProfileId:  dp.ID.Bytes(),
+						ServiceProfileId: sp.ID.Bytes(),
+						RoutingProfileId: rp.ID.Bytes(),
 						SkipFCntCheck:    true,
 					})
 				})
@@ -463,8 +463,8 @@ func TestNetworkServerAPI(t *testing.T) {
 					_, err = api.UpdateDevice(ctx, &ns.UpdateDeviceRequest{
 						Device: &ns.Device{
 							DevEui:           devEUI[:],
-							DeviceProfileId:  dp.ID[:],
-							ServiceProfileId: sp.ID[:],
+							DeviceProfileId:  dp.ID.Bytes(),
+							ServiceProfileId: sp.ID.Bytes(),
 							RoutingProfileId: rp2Resp.Id,
 							SkipFCntCheck:    true,
 						},
@@ -477,8 +477,8 @@ func TestNetworkServerAPI(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(resp.Device, ShouldResemble, &ns.Device{
 						DevEui:           devEUI[:],
-						DeviceProfileId:  dp.ID[:],
-						ServiceProfileId: sp.ID[:],
+						DeviceProfileId:  dp.ID.Bytes(),
+						ServiceProfileId: sp.ID.Bytes(),
 						RoutingProfileId: rp2Resp.Id,
 						SkipFCntCheck:    true,
 					})

--- a/internal/api/network_server_test.go
+++ b/internal/api/network_server_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -430,9 +430,9 @@ func TestNetworkServerAPI(t *testing.T) {
 				_, err := api.CreateDevice(ctx, &ns.CreateDeviceRequest{
 					Device: &ns.Device{
 						DevEui:           devEUI[:],
-						DeviceProfileId:  dp.ID.Bytes(),
-						ServiceProfileId: sp.ID.Bytes(),
-						RoutingProfileId: rp.ID.Bytes(),
+						DeviceProfileId:  dp.ID[:],
+						ServiceProfileId: sp.ID[:],
+						RoutingProfileId: rp.ID[:],
 						SkipFCntCheck:    true,
 					},
 				})
@@ -445,9 +445,9 @@ func TestNetworkServerAPI(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(resp.Device, ShouldResemble, &ns.Device{
 						DevEui:           devEUI[:],
-						DeviceProfileId:  dp.ID.Bytes(),
-						ServiceProfileId: sp.ID.Bytes(),
-						RoutingProfileId: rp.ID.Bytes(),
+						DeviceProfileId:  dp.ID[:],
+						ServiceProfileId: sp.ID[:],
+						RoutingProfileId: rp.ID[:],
 						SkipFCntCheck:    true,
 					})
 				})
@@ -463,8 +463,8 @@ func TestNetworkServerAPI(t *testing.T) {
 					_, err = api.UpdateDevice(ctx, &ns.UpdateDeviceRequest{
 						Device: &ns.Device{
 							DevEui:           devEUI[:],
-							DeviceProfileId:  dp.ID.Bytes(),
-							ServiceProfileId: sp.ID.Bytes(),
+							DeviceProfileId:  dp.ID[:],
+							ServiceProfileId: sp.ID[:],
 							RoutingProfileId: rp2Resp.Id,
 							SkipFCntCheck:    true,
 						},
@@ -477,8 +477,8 @@ func TestNetworkServerAPI(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(resp.Device, ShouldResemble, &ns.Device{
 						DevEui:           devEUI[:],
-						DeviceProfileId:  dp.ID.Bytes(),
-						ServiceProfileId: sp.ID.Bytes(),
+						DeviceProfileId:  dp.ID[:],
+						ServiceProfileId: sp.ID[:],
 						RoutingProfileId: rp2Resp.Id,
 						SkipFCntCheck:    true,
 					})

--- a/internal/storage/device.go
+++ b/internal/storage/device.go
@@ -3,8 +3,8 @@ package storage
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/brocaar/lorawan"

--- a/internal/storage/device.go
+++ b/internal/storage/device.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 

--- a/internal/storage/device_profile.go
+++ b/internal/storage/device_profile.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 
@@ -54,7 +54,7 @@ func CreateDeviceProfile(db sqlx.Execer, dp *DeviceProfile) error {
 	now := time.Now()
 
 	if dp.ID == uuid.Nil {
-		dp.ID = uuid.New()
+		dp.ID = uuid.Must(uuid.NewV4())
 	}
 
 	dp.CreatedAt = now

--- a/internal/storage/device_profile.go
+++ b/internal/storage/device_profile.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/lib/pq"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/brocaar/loraserver/internal/config"
@@ -54,7 +54,7 @@ func CreateDeviceProfile(db sqlx.Execer, dp *DeviceProfile) error {
 	now := time.Now()
 
 	if dp.ID == uuid.Nil {
-		dp.ID = uuid.NewV4()
+		dp.ID = uuid.New()
 	}
 
 	dp.CreatedAt = now

--- a/internal/storage/device_queue.go
+++ b/internal/storage/device_queue.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/brocaar/loraserver/internal/gps"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 
 	"github.com/brocaar/loraserver/api/as"
 	"github.com/brocaar/loraserver/internal/config"

--- a/internal/storage/device_queue.go
+++ b/internal/storage/device_queue.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/brocaar/loraserver/internal/gps"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 
 	"github.com/brocaar/loraserver/api/as"
 	"github.com/brocaar/loraserver/internal/config"

--- a/internal/storage/device_session.go
+++ b/internal/storage/device_session.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/garyburd/redigo/redis"
 	proto "github.com/golang/protobuf/proto"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
 	commonPB "github.com/brocaar/loraserver/api/common"
@@ -591,9 +591,9 @@ func deviceSessionToPB(d DeviceSession) DeviceSessionPB {
 }
 
 func deviceSessionFromPB(d DeviceSessionPB) DeviceSession {
-	dpID, _ := uuid.FromString(d.DeviceProfileId)
-	rpID, _ := uuid.FromString(d.RoutingProfileId)
-	spID, _ := uuid.FromString(d.ServiceProfileId)
+	dpID, _ := uuid.Parse(d.DeviceProfileId)
+	rpID, _ := uuid.Parse(d.RoutingProfileId)
+	spID, _ := uuid.Parse(d.ServiceProfileId)
 
 	out := DeviceSession{
 		MACVersion: d.MacVersion,

--- a/internal/storage/device_session.go
+++ b/internal/storage/device_session.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/garyburd/redigo/redis"
+	"github.com/gofrs/uuid"
 	proto "github.com/golang/protobuf/proto"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -591,9 +591,9 @@ func deviceSessionToPB(d DeviceSession) DeviceSessionPB {
 }
 
 func deviceSessionFromPB(d DeviceSessionPB) DeviceSession {
-	dpID, _ := uuid.Parse(d.DeviceProfileId)
-	rpID, _ := uuid.Parse(d.RoutingProfileId)
-	spID, _ := uuid.Parse(d.ServiceProfileId)
+	dpID, _ := uuid.FromString(d.DeviceProfileId)
+	rpID, _ := uuid.FromString(d.RoutingProfileId)
+	spID, _ := uuid.FromString(d.ServiceProfileId)
 
 	out := DeviceSession{
 		MACVersion: d.MacVersion,

--- a/internal/storage/device_session_old.go
+++ b/internal/storage/device_session_old.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brocaar/loraserver/internal/models"
 	"github.com/brocaar/lorawan"
 	"github.com/brocaar/lorawan/band"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 )
 
 // DeviceSessionOld defines the "old" device-session struct.
@@ -89,9 +89,9 @@ type DeviceSessionOld struct {
 }
 
 func migrateDeviceSessionOld(d DeviceSessionOld) DeviceSession {
-	dpID, _ := uuid.Parse(d.DeviceProfileID)
-	spID, _ := uuid.Parse(d.ServiceProfileID)
-	rpID, _ := uuid.Parse(d.RoutingProfileID)
+	dpID, _ := uuid.FromString(d.DeviceProfileID)
+	spID, _ := uuid.FromString(d.ServiceProfileID)
+	rpID, _ := uuid.FromString(d.RoutingProfileID)
 
 	out := DeviceSession{
 		MACVersion: "1.0.2",

--- a/internal/storage/device_session_old.go
+++ b/internal/storage/device_session_old.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brocaar/loraserver/internal/models"
 	"github.com/brocaar/lorawan"
 	"github.com/brocaar/lorawan/band"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // DeviceSessionOld defines the "old" device-session struct.
@@ -89,9 +89,9 @@ type DeviceSessionOld struct {
 }
 
 func migrateDeviceSessionOld(d DeviceSessionOld) DeviceSession {
-	dpID, _ := uuid.FromString(d.DeviceProfileID)
-	spID, _ := uuid.FromString(d.ServiceProfileID)
-	rpID, _ := uuid.FromString(d.RoutingProfileID)
+	dpID, _ := uuid.Parse(d.DeviceProfileID)
+	spID, _ := uuid.Parse(d.ServiceProfileID)
+	rpID, _ := uuid.Parse(d.RoutingProfileID)
 
 	out := DeviceSession{
 		MACVersion: "1.0.2",

--- a/internal/storage/gateway.go
+++ b/internal/storage/gateway.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/brocaar/lorawan"

--- a/internal/storage/gateway.go
+++ b/internal/storage/gateway.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"

--- a/internal/storage/gateway_profile.go
+++ b/internal/storage/gateway_profile.go
@@ -3,9 +3,9 @@ package storage
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -47,7 +47,7 @@ func CreateGatewayProfile(db sqlx.Execer, c *GatewayProfile) error {
 	c.UpdatedAt = now
 
 	if c.ID == uuid.Nil {
-		c.ID = uuid.NewV4()
+		c.ID = uuid.New()
 	}
 
 	_, err := db.Exec(`

--- a/internal/storage/gateway_profile.go
+++ b/internal/storage/gateway_profile.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
@@ -47,7 +47,7 @@ func CreateGatewayProfile(db sqlx.Execer, c *GatewayProfile) error {
 	c.UpdatedAt = now
 
 	if c.ID == uuid.Nil {
-		c.ID = uuid.New()
+		c.ID = uuid.Must(uuid.NewV4())
 	}
 
 	_, err := db.Exec(`

--- a/internal/storage/routing_profile.go
+++ b/internal/storage/routing_profile.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 )
@@ -24,7 +24,7 @@ func CreateRoutingProfile(db sqlx.Execer, rp *RoutingProfile) error {
 	now := time.Now()
 
 	if rp.ID == uuid.Nil {
-		rp.ID = uuid.New()
+		rp.ID = uuid.Must(uuid.NewV4())
 	}
 
 	rp.CreatedAt = now

--- a/internal/storage/routing_profile.go
+++ b/internal/storage/routing_profile.go
@@ -3,8 +3,8 @@ package storage
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -24,7 +24,7 @@ func CreateRoutingProfile(db sqlx.Execer, rp *RoutingProfile) error {
 	now := time.Now()
 
 	if rp.ID == uuid.Nil {
-		rp.ID = uuid.NewV4()
+		rp.ID = uuid.New()
 	}
 
 	rp.CreatedAt = now

--- a/internal/storage/routing_profile_test.go
+++ b/internal/storage/routing_profile_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brocaar/loraserver/internal/common"
 	"github.com/brocaar/loraserver/internal/config"
 	"github.com/brocaar/loraserver/internal/test"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/internal/storage/routing_profile_test.go
+++ b/internal/storage/routing_profile_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brocaar/loraserver/internal/common"
 	"github.com/brocaar/loraserver/internal/config"
 	"github.com/brocaar/loraserver/internal/test"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/internal/storage/service_profile.go
+++ b/internal/storage/service_profile.go
@@ -9,8 +9,8 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/pkg/errors"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/brocaar/loraserver/internal/config"
@@ -61,7 +61,7 @@ func CreateServiceProfile(db sqlx.Execer, sp *ServiceProfile) error {
 	now := time.Now()
 
 	if sp.ID == uuid.Nil {
-		sp.ID = uuid.NewV4()
+		sp.ID = uuid.New()
 	}
 
 	sp.CreatedAt = now

--- a/internal/storage/service_profile.go
+++ b/internal/storage/service_profile.go
@@ -9,7 +9,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/pkg/errors"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 
@@ -61,7 +61,7 @@ func CreateServiceProfile(db sqlx.Execer, sp *ServiceProfile) error {
 	now := time.Now()
 
 	if sp.ID == uuid.Nil {
-		sp.ID = uuid.New()
+		sp.ID = uuid.Must(uuid.NewV4())
 	}
 
 	sp.CreatedAt = now


### PR DESCRIPTION
Internally, we have flagged satori/go.uuid as an insecure library (and the transitive use of it by loraserver is tagging our infra as insecure). For details on the issue with the original library, see https://github.com/satori/go.uuid/issues/73.

We have taken the liberty of replacing uses of the abandoned library with Google's UUID library (which has a similar API). This is the library our team has chosen to use in place of satori/go.uuid. If the spirit of this PR is fine with you but would prefer a different library, we will apply the effort of using the one you choose instead.