### PR TITLE
Removing redis connection url from log info

### DIFF
--- a/cmd/loraserver/cmd/root_run.go
+++ b/cmd/loraserver/cmd/root_run.go
@@ -187,7 +187,7 @@ func enableUplinkChannels() error {
 }
 
 func setRedisPool() error {
-	log.WithField("url", config.C.Redis.URL).Info("setup redis connection pool")
+	log.Info("setting up redis connection pool")
 	config.C.Redis.Pool = common.NewRedisPool(config.C.Redis.URL)
 	return nil
 }


### PR DESCRIPTION
When redis url is configured with username and password, it prints the entire url which compromises the credentials. So, removing the connection string from being printed through info. 