### PR TITLE
Adding frequency as part of the lock key

### DIFF
--- a/internal/backend/gateway/mqtt/backend.go
+++ b/internal/backend/gateway/mqtt/backend.go
@@ -243,7 +243,7 @@ func (b *Backend) rxPacketHandler(c paho.Client, msg paho.Message) {
 	// so that other instances can ignore the same message (from the same gw).
 	// As an unique id, the gw mac + hex encoded payload is used. This is because
 	// we can't trust any of the data, as the MIC hasn't been validated yet.
-	key := fmt.Sprintf("lora:ns:uplink:lock:%s:%s", gatewayID, hex.EncodeToString(uplinkFrame.PhyPayload))
+	key := fmt.Sprintf("lora:ns:uplink:lock:%s:%s:%s", gatewayID, fmt.Sprint(uplinkFrame.TxInfo.Frequency), hex.EncodeToString(uplinkFrame.PhyPayload))
 	redisConn := b.redisPool.Get()
 	defer redisConn.Close()
 

--- a/internal/backend/gateway/mqtt/backend.go
+++ b/internal/backend/gateway/mqtt/backend.go
@@ -243,7 +243,7 @@ func (b *Backend) rxPacketHandler(c paho.Client, msg paho.Message) {
 	// so that other instances can ignore the same message (from the same gw).
 	// As an unique id, the gw mac + hex encoded payload is used. This is because
 	// we can't trust any of the data, as the MIC hasn't been validated yet.
-	key := fmt.Sprintf("lora:ns:uplink:lock:%s:%s:%s", gatewayID, fmt.Sprint(uplinkFrame.TxInfo.Frequency), hex.EncodeToString(uplinkFrame.PhyPayload))
+	key := fmt.Sprintf("lora:ns:uplink:lock:%s:%d:%s", gatewayID, uplinkFrame.TxInfo.Frequency, hex.EncodeToString(uplinkFrame.PhyPayload))
 	redisConn := b.redisPool.Get()
 	defer redisConn.Close()
 


### PR DESCRIPTION
This would prevent the duplicate uplink packets due to multiple Rx paths from getting dropped.
Fixes #401 

Output from `redis-cli monitor`

_Before change:_
```
1562097425.235034 [0 10.112.147.63:51622] "SET" "lora:ns:uplink:lock:d34f34d34d346b4d:8092a08901040b000306030002fc9f10d8a052fd389e" "lock" "PX" "500" "NX"
```

_After change:_
```
1562098084.656540 [0 10.112.147.63:53561] "SET" "lora:ns:uplink:lock:d34f34d34d346b4d:868100000:8092a08901040b000306030002fc9f10d8a052fd389e" "lock" "PX" "500" "NX"
```
