### PR TITLE
Return explicit errors.

### DIFF
--- a/internal/storage/device_session.go
+++ b/internal/storage/device_session.go
@@ -437,6 +437,9 @@ func GetDeviceSessionForPHYPayload(ctx context.Context, p *redis.Pool, phy loraw
 	if err != nil {
 		return DeviceSession{}, err
 	}
+	if len(sessions) == 0 {
+		return DeviceSession{}, ErrDoesNotExist
+	}
 
 	for _, s := range sessions {
 		// reset to the original FCnt
@@ -451,7 +454,6 @@ func GetDeviceSessionForPHYPayload(ctx context.Context, p *redis.Pool, phy loraw
 			// downlink frame-counter on a re-transmit, which is not what we
 			// want.
 			if s.SkipFCntValidation {
-				fullFCnt = macPL.FHDR.FCnt
 				s.FCntUp = macPL.FHDR.FCnt
 				s.UplinkHistory = []UplinkHistory{}
 
@@ -491,7 +493,7 @@ func GetDeviceSessionForPHYPayload(ctx context.Context, p *redis.Pool, phy loraw
 		}
 	}
 
-	return DeviceSession{}, ErrDoesNotExistOrFCntOrMICInvalid
+	return DeviceSession{}, ErrFCntInvalid
 }
 
 // DeviceSessionExists returns a bool indicating if a device session exist.

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrAlreadyExists                  = errors.New("object already exists")
 	ErrDoesNotExist                   = errors.New("object does not exist")
 	ErrDoesNotExistOrFCntOrMICInvalid = errors.New("device-session does not exist or invalid fcnt or mic")
+	ErrFCntInvalid                    = errors.New("invalid fcnt")
 	ErrInvalidAggregationInterval     = errors.New("invalid aggregation interval")
 	ErrInvalidName                    = errors.New("invalid gateway name")
 	ErrInvalidFPort                   = errors.New("invalid fPort (must be > 0)")


### PR DESCRIPTION
`ErrDoesNotExistOrFCntOrMICInvalid` has 3 error reasons, it confused me. I think we can make this error more explicit.

`fullFCnt` not used in `if s.SkipFCntValidation` condition, so I remove it.